### PR TITLE
Include src/vendor/ directory in build archive

### DIFF
--- a/build-zip.js
+++ b/build-zip.js
@@ -43,6 +43,10 @@ archive.file('src/lib/localize.js', { name: 'src/lib/localize.js' });
 archive.file('src/lib/locale-utils.js', { name: 'src/lib/locale-utils.js' });
 archive.glob('*.min.js', { cwd: 'src/lib' }, { prefix: 'src/lib' });
 
+// src/vendor/ - Bootstrap, Popper, etc.
+console.log('  ✓ src/vendor/');
+archive.directory('src/vendor/', 'src/vendor');
+
 // _locales/
 console.log('  ✓ _locales/');
 archive.directory('_locales/', '_locales');


### PR DESCRIPTION
## Summary
Added the `src/vendor/` directory to the build archive output, ensuring that vendor dependencies (Bootstrap, Popper, etc.) are included in the packaged distribution.

## Changes
- Added `src/vendor/` directory to the archive build process in `build-zip.js`
- Included console logging to indicate successful inclusion of the vendor directory
- Maintains consistent directory structure in the final archive output

## Details
The vendor directory is now archived with the same prefix structure (`src/vendor`) to preserve the relative path organization in the final distribution package.

https://claude.ai/code/session_011yGundLM8c9C1zGBy3nF4f