### PR TITLE
Exclude vendor CSS files from build archive

### DIFF
--- a/build-zip.js
+++ b/build-zip.js
@@ -35,7 +35,7 @@ archive.directory('dist/', 'dist');
 // src/ - HTML and CSS only
 console.log('  ✓ src/ (HTML, CSS, images, libs)');
 archive.glob('**/*.html', { cwd: 'src' }, { prefix: 'src' });
-archive.glob('**/*.css', { cwd: 'src' }, { prefix: 'src' });
+archive.glob('**/*.css', { cwd: 'src', ignore: ['vendor/**'] }, { prefix: 'src' });
 archive.directory('src/img/', 'src/img');
 
 // src/lib/ - Non-JS files and specific required JS files


### PR DESCRIPTION
## Summary
Updated the build script to exclude vendor CSS files from the distribution archive, preventing unnecessary third-party stylesheets from being included in the final package.

## Changes
- Modified the CSS glob pattern in `build-zip.js` to ignore vendor CSS files by adding an `ignore` filter that excludes the `vendor/**` directory

## Details
The CSS archiving step now uses `{ cwd: 'src', ignore: ['vendor/**'] }` to prevent vendor CSS files from being packaged. This reduces the archive size and ensures only project-specific stylesheets are included in the build output.

https://claude.ai/code/session_012BHhBfQnLiZsVixjf7ucCZ