### PR TITLE
Add support for Google Calendar out-of-office events

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -609,6 +609,10 @@
     "message": "No Title",
     "description": "Default text when event has no title"
   },
+  "outOfOffice": {
+    "message": "Out of office",
+    "description": "Label for out of office events from Google Calendar"
+  },
   "noTimeInfo": {
     "message": "No time information",
     "description": "Text when event time information is missing"

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -609,6 +609,10 @@
     "message": "タイトルなし",
     "description": "イベントにタイトルがない場合のデフォルトテキスト"
   },
+  "outOfOffice": {
+    "message": "不在",
+    "description": "Google Calendarの不在予定のラベル"
+  },
   "noTimeInfo": {
     "message": "時刻情報なし",
     "description": "イベントの時刻情報がない場合のテキスト"

--- a/src/lib/demo-data.js
+++ b/src/lib/demo-data.js
@@ -308,6 +308,25 @@ function _devTeamEvents(today, locale) {
             calendarBackgroundColor: '#FFC107',
             calendarForegroundColor: '#000000',
             htmlLink: 'https://calendar.google.com/calendar/event?eid=demo13'
+        },
+        // 13:00–18:00  Out of office (half-day PTO)
+        {
+            id: 'demo-ooo-1',
+            summary:  T('Out of office', '不在'),
+            description: T('On PTO - back tomorrow', '有休取得中 - 明日戻ります'),
+            location: '',
+            start: { dateTime: _d(today, 13, 0) },
+            end:   { dateTime: _d(today, 18, 0) },
+            eventType: 'outOfOffice',
+            outOfOfficeProperties: {
+                autoDeclineMode: 'declineAllConflictingInvitations',
+                declineMessage: T('I am out of the office and will respond when I return.', '不在のため、戻り次第対応いたします。')
+            },
+            calendarId: 'casey@team.com',
+            calendarName: T('Casey Morgan', '中村 真由美'),
+            calendarBackgroundColor: '#00BCD4',
+            calendarForegroundColor: '#FFFFFF',
+            htmlLink: 'https://calendar.google.com/calendar/event?eid=demo-ooo-1'
         }
     ];
 }

--- a/src/side_panel/components/modals/google-event-modal.js
+++ b/src/side_panel/components/modals/google-event-modal.js
@@ -97,7 +97,7 @@ export class GoogleEventModal extends ModalComponent {
             const titleLink = document.createElement('a');
             titleLink.href = event.htmlLink;
             titleLink.target = '_blank';
-            titleLink.textContent = event.summary || window.getLocalizedMessage('noTitle');
+            titleLink.textContent = event.summary || (event.eventType === 'outOfOffice' ? window.getLocalizedMessage('outOfOffice') : window.getLocalizedMessage('noTitle'));
             titleLink.style.cssText = 'color: inherit; text-decoration: none;';
             titleLink.addEventListener('mouseenter', () => {
                 titleLink.style.textDecoration = 'underline';
@@ -114,7 +114,7 @@ export class GoogleEventModal extends ModalComponent {
                 this.titleElement.appendChild(colorIndicator);
             }
             const titleText = document.createElement('span');
-            titleText.textContent = event.summary || window.getLocalizedMessage('noTitle');
+            titleText.textContent = event.summary || (event.eventType === 'outOfOffice' ? window.getLocalizedMessage('outOfOffice') : window.getLocalizedMessage('noTitle'));
             this.titleElement.appendChild(titleText);
         }
 

--- a/src/side_panel/components/modals/google-event-modal.js
+++ b/src/side_panel/components/modals/google-event-modal.js
@@ -62,6 +62,11 @@ export class GoogleEventModal extends ModalComponent {
         this.meetElement.className = 'google-event-row google-event-meet';
         content.appendChild(this.meetElement);
 
+        // Out of office information
+        this.oooInfoElement = document.createElement('div');
+        this.oooInfoElement.className = 'google-event-row google-event-ooo-info mb-2';
+        content.appendChild(this.oooInfoElement);
+
         // Save the reference to the modalBody
         this.modalBody = content;
 
@@ -128,11 +133,17 @@ export class GoogleEventModal extends ModalComponent {
         // Meet information
         this._setMeetInfo(event);
 
-        // Attendees information
-        this._setAttendeesInfo(event);
+        // Out of office information
+        this._setOutOfOfficeInfo(event);
 
-        // RSVP buttons
-        this._setRsvpButtons(event);
+        // Attendees and RSVP (skip for out-of-office events)
+        if (event.eventType === 'outOfOffice') {
+            if (this.attendeesElement) this.attendeesElement.innerHTML = '';
+            if (this.rsvpContainer) this.rsvpContainer.innerHTML = '';
+        } else {
+            this._setAttendeesInfo(event);
+            this._setRsvpButtons(event);
+        }
 
         this.show();
 
@@ -297,6 +308,26 @@ export class GoogleEventModal extends ModalComponent {
             this.meetElement.appendChild(icon);
             this.meetElement.appendChild(link);
         }
+    }
+
+    /**
+     * Set out of office information
+     * @private
+     */
+    _setOutOfOfficeInfo(event) {
+        this.oooInfoElement.innerHTML = '';
+
+        if (event.eventType !== 'outOfOffice') return;
+
+        const icon = document.createElement('i');
+        icon.className = 'fas fa-plane-departure me-1';
+
+        const text = document.createElement('span');
+        const declineMessage = event.outOfOfficeProperties?.declineMessage;
+        text.textContent = declineMessage || window.getLocalizedMessage('outOfOffice');
+
+        this.oooInfoElement.appendChild(icon);
+        this.oooInfoElement.appendChild(text);
     }
 
     /**

--- a/src/side_panel/event-handlers.js
+++ b/src/side_panel/event-handlers.js
@@ -239,8 +239,12 @@ export class GoogleEventManager {
                 switch (event.eventType) {
                     case 'workingLocation':
                     case 'focusTime':
-                    case 'outOfOffice':
                         continue;
+                    case 'outOfOffice': {
+                        const uniqueEvent = { ...event, uniqueId };
+                        await this._createGoogleEventElement(uniqueEvent, { isOutOfOffice: true });
+                        break;
+                    }
                     case 'default': {
                         const uniqueEvent = { ...event, uniqueId };
                         await this._createGoogleEventElement(uniqueEvent);
@@ -259,7 +263,7 @@ export class GoogleEventManager {
      * Create a Google event element
      * @private
      */
-    async _createGoogleEventElement(event) {
+    async _createGoogleEventElement(event, options = {}) {
         // Skip all-day events
         if (event.start.date || event.end.date) {
             return;
@@ -274,11 +278,15 @@ export class GoogleEventManager {
         }
 
         // Create the positioned event element via the factory
+        const cssClass = options.isOutOfOffice
+            ? 'event google-event google-event-ooo'
+            : 'event google-event';
+        const title = event.summary || (options.isOutOfOffice ? window.getLocalizedMessage('outOfOffice') : '');
         const { eventDiv } = EventElementFactory.createEventElement({
             startDate,
             endDate,
-            cssClass: 'event google-event',
-            tooltip: event.summary,
+            cssClass,
+            tooltip: title,
             initialWidth: this.eventLayoutManager.maxWidth
         });
 
@@ -299,14 +307,14 @@ export class GoogleEventManager {
             }
         });
 
-        // Apply the Google colors directly (unless disabled by user setting)
-        if (this.useGoogleCalendarColors && event.calendarBackgroundColor) {
+        // Apply the Google colors directly (unless disabled by user setting or OOO event)
+        if (this.useGoogleCalendarColors && event.calendarBackgroundColor && !options.isOutOfOffice) {
             eventDiv.style.backgroundColor = event.calendarBackgroundColor;
             eventDiv.style.color = event.calendarForegroundColor;
         }
 
         // Set the locale-aware time display asynchronously (with attendee information)
-        await this._setEventContentWithLocale(eventDiv, startDate, event.summary, event);
+        await this._setEventContentWithLocale(eventDiv, startDate, title, event);
 
         this.googleEventsDiv.appendChild(eventDiv);
 

--- a/src/side_panel/side_panel.css
+++ b/src/side_panel/side_panel.css
@@ -5,6 +5,9 @@
     --side-calendar-break-time-color: #bcdcfb;
     --side-calendar-local-event-color: #bbf2b1;
     --side-calendar-google-event-default-color: #fff0b8;
+    --side-calendar-ooo-event-color: #e8e8e8;
+    --side-calendar-ooo-event-text-color: #666666;
+    --side-calendar-ooo-event-stripe-color: rgba(0, 0, 0, 0.06);
     --side-calendar-current-time-line-color: #ff0000;
     /* Computed text colors (auto-set by JS based on background luminance) */
     --side-calendar-timeline-text-color: #000000;
@@ -269,6 +272,25 @@ body {
 
 .google-event {
     /* Background color is set dynamically from Google Calendar API */
+}
+
+.google-event-ooo {
+    background-color: var(--side-calendar-ooo-event-color);
+    color: var(--side-calendar-ooo-event-text-color);
+    background-image: repeating-linear-gradient(
+        135deg,
+        transparent,
+        transparent 4px,
+        var(--side-calendar-ooo-event-stripe-color) 4px,
+        var(--side-calendar-ooo-event-stripe-color) 8px
+    );
+    opacity: 0.85;
+}
+
+[data-theme="dark"] .google-event-ooo {
+    --side-calendar-ooo-event-color: #3a3a3a;
+    --side-calendar-ooo-event-text-color: #aaaaaa;
+    --side-calendar-ooo-event-stripe-color: rgba(255, 255, 255, 0.06);
 }
 
 .local-event {

--- a/src/side_panel/side_panel.css
+++ b/src/side_panel/side_panel.css
@@ -5,15 +5,16 @@
     --side-calendar-break-time-color: #bcdcfb;
     --side-calendar-local-event-color: #bbf2b1;
     --side-calendar-google-event-default-color: #fff0b8;
-    --side-calendar-ooo-event-color: #e8e8e8;
-    --side-calendar-ooo-event-text-color: #666666;
-    --side-calendar-ooo-event-stripe-color: rgba(0, 0, 0, 0.06);
     --side-calendar-current-time-line-color: #ff0000;
     /* Computed text colors (auto-set by JS based on background luminance) */
     --side-calendar-timeline-text-color: #000000;
     --side-calendar-panel-text-color: #000000;
     --side-calendar-google-event-default-text-color: #000000;
     --side-calendar-local-event-text-color: #000000;
+    /* Out of office event colors */
+    --side-calendar-ooo-event-color: #e8e8e8;
+    --side-calendar-ooo-event-text-color: #666666;
+    --side-calendar-ooo-event-stripe-color: rgba(0, 0, 0, 0.06);
     /* UI chrome colors (borders, shadows, secondary text) */
     --side-calendar-border-color: #ccc;
     --side-calendar-border-color-light: #ddd;
@@ -284,7 +285,6 @@ body {
         var(--side-calendar-ooo-event-stripe-color) 4px,
         var(--side-calendar-ooo-event-stripe-color) 8px
     );
-    opacity: 0.85;
 }
 
 [data-theme="dark"] .google-event-ooo {


### PR DESCRIPTION
## Summary
This PR adds comprehensive support for displaying Google Calendar out-of-office (OOO) events in the side panel calendar. Out-of-office events are now rendered with a distinctive visual style and display relevant information without attendee/RSVP options.

## Key Changes

- **Event Modal Updates**: Added a new `oooInfoElement` to display out-of-office information with an icon and decline message. Modified title display logic to show "Out of office" label when event has no summary.

- **Event Filtering & Rendering**: Changed event processing to include out-of-office events (previously skipped). Out-of-office events are now created with a special `isOutOfOffice` flag and rendered with a distinct CSS class (`google-event-ooo`).

- **UI Styling**: Added CSS variables and styles for out-of-office events with a light gray background and diagonal stripe pattern (with dark mode support). The striped pattern provides visual distinction from regular events.

- **Modal Behavior**: Out-of-office events skip attendee information and RSVP buttons in the event modal, showing only the decline message instead.

- **Localization**: Added "outOfOffice" message keys in English and Japanese locale files.

- **Demo Data**: Added a sample out-of-office event to the demo calendar data for testing purposes.

## Implementation Details

- Out-of-office events are identified by `eventType === 'outOfOffice'` from the Google Calendar API
- The `declineMessage` from `outOfOfficeProperties` is displayed in the modal when available
- Color application from Google Calendar is skipped for OOO events to maintain the distinctive striped appearance
- The implementation maintains backward compatibility with existing event handling

https://claude.ai/code/session_013e4LWxcNigQEFU3uvMEtwK