### PR TITLE
Fix checkbox interactions in memo preview panel

### DIFF
--- a/src/side_panel/components/memo/memo-component.js
+++ b/src/side_panel/components/memo/memo-component.js
@@ -129,6 +129,7 @@ export class MemoComponent extends Component {
         });
         this.addEventListener(this._preview, 'click', (e) => {
             if (e.target.matches('input[type="checkbox"]')) {
+                e.preventDefault();
                 this._toggleCheckbox(e.target);
                 return;
             }
@@ -368,6 +369,7 @@ export class MemoComponent extends Component {
         let checkboxIndex = 0;
         this._preview.querySelectorAll('li > input[type="checkbox"]').forEach(cb => {
             cb.dataset.cbIndex = checkboxIndex++;
+            cb.removeAttribute('disabled');
         });
     }
 


### PR DESCRIPTION
## Summary
Fixed checkbox behavior in the memo component's preview panel by preventing default click behavior and ensuring checkboxes are not disabled when rendered.

## Key Changes
- Added `e.preventDefault()` to the checkbox click handler to prevent default browser checkbox behavior and allow custom toggle logic to handle state changes
- Removed the `disabled` attribute from checkboxes during preview rendering to ensure they are interactive and can be toggled by users

## Implementation Details
These changes ensure that checkboxes in the memo preview panel function correctly with the custom `_toggleCheckbox()` method without interference from default browser behavior or disabled states.

https://claude.ai/code/session_016FKuvN6DX7nxLZ9TVXZThU