### PR TITLE
Fix icon alignment in Google event details using baseline

### DIFF
--- a/src/side_panel/components/modals/google-event-modal.js
+++ b/src/side_panel/components/modals/google-event-modal.js
@@ -369,7 +369,7 @@ export class GoogleEventModal extends ModalComponent {
         if (realAttendees.length > 0) {
             const icon = document.createElement('i');
             icon.className = 'fas fa-users me-1';
-            icon.style.cssText = 'margin-top: 2px; color: var(--side-calendar-secondary-text-color);';
+            icon.style.cssText = 'color: var(--side-calendar-secondary-text-color);';
 
             const container = document.createElement('div');
             container.className = 'google-event-detail-text';
@@ -469,7 +469,7 @@ export class GoogleEventModal extends ModalComponent {
 
         const icon = document.createElement('i');
         icon.className = 'fas fa-reply me-1';
-        icon.style.cssText = 'margin-top: 6px; color: var(--side-calendar-secondary-text-color);';
+        icon.style.cssText = 'color: var(--side-calendar-secondary-text-color);';
 
         const buttonsWrapper = document.createElement('div');
         buttonsWrapper.className = 'google-event-rsvp-wrapper';

--- a/src/side_panel/side_panel.css
+++ b/src/side_panel/side_panel.css
@@ -700,7 +700,7 @@ body {
 /* Google event detail rows (icon + text alignment) */
 .google-event-row {
     display: flex;
-    align-items: flex-start;
+    align-items: baseline;
     gap: 8px;
 }
 
@@ -708,7 +708,6 @@ body {
     width: 16px;
     flex: 0 0 16px;
     text-align: center;
-    margin-top: 2px;
     color: var(--side-calendar-secondary-text-color);
 }
 
@@ -733,7 +732,7 @@ body {
 /* RSVP response buttons */
 .google-event-rsvp {
     display: flex;
-    align-items: flex-start;
+    align-items: baseline;
     gap: 8px;
 }
 


### PR DESCRIPTION
## Summary
Improved the vertical alignment of icons in Google event detail rows and RSVP sections by switching from `flex-start` with manual margin adjustments to `baseline` alignment, which provides more consistent and maintainable positioning.

## Key Changes
- Changed `.google-event-row` and `.google-event-rsvp` flex containers from `align-items: flex-start` to `align-items: baseline` for better icon-text alignment
- Removed hardcoded `margin-top: 2px` from `.google-event-row i` CSS rule
- Removed inline `margin-top: 2px` style from the attendees icon in `google-event-modal.js`
- Removed inline `margin-top: 6px` style from the RSVP reply icon in `google-event-modal.js`

## Implementation Details
The `baseline` alignment value naturally aligns flex items based on their text baseline, eliminating the need for manual margin adjustments. This approach is more robust and reduces the amount of hardcoded spacing values, making the code easier to maintain and more consistent across different icon sizes and font metrics.

https://claude.ai/code/session_01WTR4QqN67JeKiT6AXyiAPP