### PR TITLE
feat: イベント詳細モーダルに日付を表示

### DIFF
--- a/src/side_panel/components/modals/google-event-content-builder.js
+++ b/src/side_panel/components/modals/google-event-content-builder.js
@@ -91,11 +91,23 @@ export class GoogleEventContentBuilder {
             // For the timed events - use browser locale
             const locale = navigator.language || 'en';
             const timeOptions = { hour: '2-digit', minute: '2-digit' };
+            const dateOptions = { year: 'numeric', month: '2-digit', day: '2-digit' };
             const startTime = startDate.toLocaleTimeString(locale, timeOptions);
             const endTime = endDate.toLocaleTimeString(locale, timeOptions);
+            const startDateStr = startDate.toLocaleDateString(locale, dateOptions);
             const separator = locale.startsWith('ja') ? ' ～ ' : ' - ';
 
-            return `${startTime}${separator}${endTime}`;
+            // If the event spans multiple calendar days, show the end date as well
+            const sameDay = startDate.getFullYear() === endDate.getFullYear()
+                && startDate.getMonth() === endDate.getMonth()
+                && startDate.getDate() === endDate.getDate();
+
+            if (sameDay) {
+                return `${startDateStr} ${startTime}${separator}${endTime}`;
+            }
+
+            const endDateStr = endDate.toLocaleDateString(locale, dateOptions);
+            return `${startDateStr} ${startTime}${separator}${endDateStr} ${endTime}`;
         } catch (error) {
             console.warn('Time format error:', error);
             return window.getLocalizedMessage('timeInfoError');

--- a/src/side_panel/components/modals/google-event-content-builder.js
+++ b/src/side_panel/components/modals/google-event-content-builder.js
@@ -85,7 +85,10 @@ export class GoogleEventContentBuilder {
                     }
                     return `${startStr} – ${endStr} (${dayCount} days)`;
                 }
-                return window.getLocalizedMessage('allDay');
+                const locale = navigator.language || 'en';
+                const dateOpts = { year: 'numeric', month: '2-digit', day: '2-digit' };
+                const dateStr = localStart.toLocaleDateString(locale, dateOpts);
+                return `${dateStr} ${window.getLocalizedMessage('allDay')}`;
             }
 
             // For the timed events - use browser locale

--- a/src/side_panel/components/modals/local-event-modal.js
+++ b/src/side_panel/components/modals/local-event-modal.js
@@ -198,7 +198,7 @@ export class LocalEventModal extends ModalComponent {
             icon.className = 'fas fa-clock';
 
             const text = document.createElement('span');
-            text.textContent = this._formatViewTime(event.startTime, event.endTime);
+            text.textContent = this._formatViewTime(event.startTime, event.endTime, this._getDisplayDate(event));
 
             this.viewTimeElement.appendChild(icon);
             this.viewTimeElement.appendChild(text);
@@ -260,26 +260,41 @@ export class LocalEventModal extends ModalComponent {
     }
 
     /**
+     * Resolve the display date for the event (recurring instance date or current panel date)
+     * @private
+     */
+    _getDisplayDate(event) {
+        if (event?.instanceDate) {
+            return new Date(event.instanceDate + 'T00:00:00');
+        }
+        if (this._getCurrentDate) {
+            return this._getCurrentDate();
+        }
+        return new Date();
+    }
+
+    /**
      * Format time for view mode display (locale-aware)
      * @private
      */
-    _formatViewTime(startTime, endTime) {
+    _formatViewTime(startTime, endTime, displayDate = new Date()) {
         try {
             const locale = navigator.language || 'en';
-            const today = new Date();
             const timeOptions = { hour: '2-digit', minute: '2-digit' };
+            const dateOptions = { year: 'numeric', month: '2-digit', day: '2-digit' };
 
             const [sh, sm] = startTime.split(':').map(Number);
             const [eh, em] = endTime.split(':').map(Number);
 
-            const startDate = new Date(today.getFullYear(), today.getMonth(), today.getDate(), sh, sm);
-            const endDate = new Date(today.getFullYear(), today.getMonth(), today.getDate(), eh, em);
+            const startDate = new Date(displayDate.getFullYear(), displayDate.getMonth(), displayDate.getDate(), sh, sm);
+            const endDate = new Date(displayDate.getFullYear(), displayDate.getMonth(), displayDate.getDate(), eh, em);
 
             const startStr = startDate.toLocaleTimeString(locale, timeOptions);
             const endStr = endDate.toLocaleTimeString(locale, timeOptions);
+            const dateStr = startDate.toLocaleDateString(locale, dateOptions);
             const separator = locale.startsWith('ja') ? ' \uff5e ' : ' - ';
 
-            return `${startStr}${separator}${endStr}`;
+            return `${dateStr} ${startStr}${separator}${endStr}`;
         } catch {
             return `${startTime} - ${endTime}`;
         }


### PR DESCRIPTION
GoogleイベントとローカルイベントのしょうさいモーダルでTimedイベントの日付を時刻の前に表示する。複数日にまたがるGoogleイベントの場合は開始・終了の両方の日付を表示する。ローカルイベントでは繰り返しインスタンスの instanceDate を、通常イベントでは現在表示中の日付を使用する。

https://claude.ai/code/session_01RELrRa33uDU52Vhha85nDp