### PR TITLE
Fix calendar leak when unchecking groups with shared members

### DIFF
--- a/src/side_panel/components/timeline/timeline-calendar-filter.js
+++ b/src/side_panel/components/timeline/timeline-calendar-filter.js
@@ -362,12 +362,9 @@ export class TimelineCalendarFilter extends Component {
                 }
             }
         } else {
-            // Preserve calendars that belong to ANOTHER fully-checked group.
-            // A group is considered fully checked when every one of its valid
-            // members is currently selected. Without this filter, calendars
-            // that happen to be members of an unrelated, only partially-
-            // selected group would leak through when their primary group is
-            // unchecked.
+            // Only preserve calendars whose sibling group is *fully* checked.
+            // A merely "selected" sibling member is not enough: it may itself
+            // be selected only via the group we are unchecking now.
             const validCalIds = new Set(this.calendars.map(c => c.id));
             const selectedSet = new Set(this.selectedIds);
             const otherGroupIds = new Set();

--- a/src/side_panel/components/timeline/timeline-calendar-filter.js
+++ b/src/side_panel/components/timeline/timeline-calendar-filter.js
@@ -362,14 +362,23 @@ export class TimelineCalendarFilter extends Component {
                 }
             }
         } else {
-            // Find calendar IDs that are in other groups and still selected
+            // Preserve calendars that belong to ANOTHER fully-checked group.
+            // A group is considered fully checked when every one of its valid
+            // members is currently selected. Without this filter, calendars
+            // that happen to be members of an unrelated, only partially-
+            // selected group would leak through when their primary group is
+            // unchecked.
+            const validCalIds = new Set(this.calendars.map(c => c.id));
+            const selectedSet = new Set(this.selectedIds);
             const otherGroupIds = new Set();
             for (const g of this.calendarGroups) {
                 if (g.id === group.id) continue;
-                for (const id of g.calendarIds) {
-                    if (this.selectedIds.includes(id)) {
-                        otherGroupIds.add(id);
-                    }
+                const memberIds = g.calendarIds.filter(id => validCalIds.has(id));
+                if (memberIds.length === 0) continue;
+                const fullyChecked = memberIds.every(id => selectedSet.has(id));
+                if (!fullyChecked) continue;
+                for (const id of memberIds) {
+                    otherGroupIds.add(id);
                 }
             }
 

--- a/tests/side_panel/timeline-calendar-filter.test.js
+++ b/tests/side_panel/timeline-calendar-filter.test.js
@@ -65,7 +65,7 @@ describe('TimelineCalendarFilter._handleGroupToggle', () => {
 
     await filter._handleGroupToggle(GROUP_A, [], true);
 
-    expect(filter.selectedIds.sort()).toEqual(['cal-x', 'cal-y']);
+    expect([...filter.selectedIds].sort()).toEqual(['cal-x', 'cal-y']);
     expect(onCalendarChange).toHaveBeenCalledWith({
       addedIds: ['cal-x', 'cal-y'],
       removedIds: [],
@@ -93,7 +93,7 @@ describe('TimelineCalendarFilter._handleGroupToggle', () => {
 
     await filter._handleGroupToggle(GROUP_A, [], false);
 
-    expect(filter.selectedIds.sort()).toEqual(['cal-y', 'cal-z']);
+    expect([...filter.selectedIds].sort()).toEqual(['cal-y', 'cal-z']);
     expect(onCalendarChange).toHaveBeenCalledWith({
       addedIds: [],
       removedIds: ['cal-x'],

--- a/tests/side_panel/timeline-calendar-filter.test.js
+++ b/tests/side_panel/timeline-calendar-filter.test.js
@@ -1,0 +1,139 @@
+/**
+ * Tests for TimelineCalendarFilter — group toggle behaviour with calendars
+ * that belong to multiple groups.
+ *
+ * Regression: switching groups must not leak calendars whose only reason for
+ * being selected is membership in a partially-selected sibling group.
+ */
+
+jest.mock('../../src/lib/chrome-messaging.js', () => ({
+  sendMessage: jest.fn(),
+}));
+jest.mock('../../src/lib/settings-storage.js', () => ({
+  loadSelectedCalendars: jest.fn(),
+  saveSelectedCalendars: jest.fn().mockResolvedValue(undefined),
+  loadCalendarGroups: jest.fn(),
+}));
+jest.mock('../../src/lib/demo-data.js', () => ({
+  isDemoMode: jest.fn(() => false),
+  getDemoCalendarGroups: jest.fn(),
+}));
+
+beforeAll(() => {
+  global.window = global.window || {};
+  global.document = global.document || {};
+  global.document.createElement = jest.fn(() => ({
+    className: '',
+    style: {},
+    dataset: {},
+    setAttribute: jest.fn(),
+    appendChild: jest.fn(),
+    addEventListener: jest.fn(),
+  }));
+  global.document.getElementById = jest.fn(() => null);
+});
+
+import { TimelineCalendarFilter } from '../../src/side_panel/components/timeline/timeline-calendar-filter.js';
+import { saveSelectedCalendars } from '../../src/lib/settings-storage.js';
+
+const CAL_X = { id: 'cal-x', summary: 'X', primary: false };
+const CAL_Y = { id: 'cal-y', summary: 'Y', primary: false };
+const CAL_Z = { id: 'cal-z', summary: 'Z', primary: false };
+
+const GROUP_A = { id: 'group-a', name: 'A', calendarIds: ['cal-x', 'cal-y'] };
+const GROUP_B = { id: 'group-b', name: 'B', calendarIds: ['cal-y', 'cal-z'] };
+
+function buildFilter({ selectedIds, groups = [GROUP_A, GROUP_B], calendars = [CAL_X, CAL_Y, CAL_Z] }) {
+  const onCalendarChange = jest.fn();
+  const filter = new TimelineCalendarFilter({ onCalendarChange });
+  filter.calendars = calendars;
+  filter.selectedIds = [...selectedIds];
+  filter.calendarGroups = groups;
+  // Stub the renderer so re-render attempts don't touch DOM.
+  filter.renderer = { renderCalendarList: jest.fn() };
+  return { filter, onCalendarChange };
+}
+
+describe('TimelineCalendarFilter._handleGroupToggle', () => {
+  beforeEach(() => {
+    saveSelectedCalendars.mockClear();
+    saveSelectedCalendars.mockResolvedValue(undefined);
+  });
+
+  test('checking a group adds all its members', async () => {
+    const { filter, onCalendarChange } = buildFilter({ selectedIds: [] });
+
+    await filter._handleGroupToggle(GROUP_A, [], true);
+
+    expect(filter.selectedIds.sort()).toEqual(['cal-x', 'cal-y']);
+    expect(onCalendarChange).toHaveBeenCalledWith({
+      addedIds: ['cal-x', 'cal-y'],
+      removedIds: [],
+    });
+  });
+
+  test('unchecking a group removes its members when no other group is fully checked', async () => {
+    // Bug repro: Y is in both A and B. After only checking A and unchecking it,
+    // Y must be removed (Group B was never activated).
+    const { filter, onCalendarChange } = buildFilter({ selectedIds: ['cal-x', 'cal-y'] });
+
+    await filter._handleGroupToggle(GROUP_A, [], false);
+
+    expect(filter.selectedIds).toEqual([]);
+    expect(onCalendarChange).toHaveBeenCalledWith({
+      addedIds: [],
+      removedIds: ['cal-x', 'cal-y'],
+    });
+  });
+
+  test('unchecking a group keeps cross-group calendars when the sibling group is fully checked', async () => {
+    // Both A and B fully checked → Y must remain after unchecking A,
+    // because Group B (still checked) requires Y.
+    const { filter, onCalendarChange } = buildFilter({ selectedIds: ['cal-x', 'cal-y', 'cal-z'] });
+
+    await filter._handleGroupToggle(GROUP_A, [], false);
+
+    expect(filter.selectedIds.sort()).toEqual(['cal-y', 'cal-z']);
+    expect(onCalendarChange).toHaveBeenCalledWith({
+      addedIds: [],
+      removedIds: ['cal-x'],
+    });
+  });
+
+  test('sequentially unchecking both groups leaves nothing selected', async () => {
+    const { filter, onCalendarChange } = buildFilter({ selectedIds: ['cal-x', 'cal-y', 'cal-z'] });
+
+    await filter._handleGroupToggle(GROUP_A, [], false);
+    await filter._handleGroupToggle(GROUP_B, [], false);
+
+    expect(filter.selectedIds).toEqual([]);
+    expect(onCalendarChange).toHaveBeenLastCalledWith({
+      addedIds: [],
+      removedIds: ['cal-y', 'cal-z'],
+    });
+  });
+
+  test('primary calendar is never removed by a group toggle', async () => {
+    const primary = { id: 'cal-primary', summary: 'Primary', primary: true };
+    const groupWithPrimary = { id: 'group-p', name: 'P', calendarIds: ['cal-primary', 'cal-x'] };
+    const { filter } = buildFilter({
+      selectedIds: ['cal-primary', 'cal-x'],
+      groups: [groupWithPrimary],
+      calendars: [primary, CAL_X],
+    });
+
+    await filter._handleGroupToggle(groupWithPrimary, [], false);
+
+    expect(filter.selectedIds).toEqual(['cal-primary']);
+  });
+
+  test('save failure rolls back selectedIds', async () => {
+    saveSelectedCalendars.mockRejectedValueOnce(new Error('boom'));
+    const { filter, onCalendarChange } = buildFilter({ selectedIds: ['cal-x', 'cal-y'] });
+
+    await filter._handleGroupToggle(GROUP_A, [], false);
+
+    expect(filter.selectedIds).toEqual(['cal-x', 'cal-y']);
+    expect(onCalendarChange).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Fixed a bug in `TimelineCalendarFilter._handleGroupToggle` where unchecking a group would incorrectly retain calendars that are shared with sibling groups, even when those sibling groups were not fully selected.

## Problem
When a calendar belongs to multiple groups (e.g., Calendar Y in both Group A and Group B), unchecking Group A would leave Calendar Y selected if it was previously selected as part of Group A. This created a "leak" where calendars remained selected even though no fully-checked group required them.

## Solution
Changed the logic for determining which calendars to preserve when unchecking a group:

- **Before**: Preserved any calendar that appeared in another group and was currently selected
- **After**: Only preserve calendars whose sibling group is *fully* checked (all members selected)

This ensures that a calendar is only retained if an intact, fully-selected group explicitly requires it, preventing calendars from persisting due to partial selections that may themselves be artifacts of the group being unchecked.

## Implementation Details
- Added validation to check that sibling groups are fully checked before preserving their shared calendars
- Introduced `fullyChecked` logic that verifies all members of a sibling group are in the selected set
- Added comprehensive test coverage including edge cases: cross-group calendars, primary calendars, and sequential group unchecking

https://claude.ai/code/session_017wJDhm8ickYJ8s7DBEwjg2