### PR TITLE
Extract conference URL detection into shared utility module

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -7,6 +7,7 @@
 
 import { StorageHelper } from './lib/storage-helper.js';
 import { AlarmManager } from './lib/alarm-manager.js';
+import { selectNotificationUrl } from './lib/conference-url-utils.js';
 import { GoogleCalendarClient, AuthenticationError } from './services/google-calendar-client.js';
 import { ReminderSyncService } from './services/reminder-sync-service.js';
 
@@ -377,7 +378,7 @@ chrome.notifications.onButtonClicked.addListener(async (notificationId, buttonIn
                 // Primary button: If Google event with Meet link, open it; otherwise open SideTimeTable
                 if (alarmName.startsWith(AlarmManager.GOOGLE_ALARM_PREFIX)) {
                     const eventData = await AlarmManager.getGoogleEventData(alarmName);
-                    const urlToOpen = eventData?.hangoutLink || eventData?.htmlLink;
+                    const urlToOpen = selectNotificationUrl(eventData);
                     if (urlToOpen) {
                         await chrome.tabs.create({ url: urlToOpen, active: true });
                     } else {

--- a/src/lib/alarm-manager.js
+++ b/src/lib/alarm-manager.js
@@ -3,6 +3,7 @@
  */
 import { STORAGE_KEYS } from './constants.js';
 import { getRecurringEventsForDate } from './event-storage.js';
+import { extractMeetUrl, extractVideoUrl } from './conference-url-utils.js';
 
 export class AlarmManager {
     static ALARM_PREFIX = 'event_reminder_';
@@ -151,8 +152,22 @@ export class AlarmManager {
             // Create the notification
             const notificationId = `reminder_${alarmName}`;
 
-            // Decide buttons dynamically (Join Meet if a Meet link exists)
-            const hasMeetLink = !!(eventData && eventData.hangoutLink);
+            // Decide the primary button label from the conference type.
+            // Legacy compatibility: pre-upgrade reminder data only has `hangoutLink` and no
+            // `conferenceType`, so synthesize 'meet' in that case.
+            let conferenceType = eventData.conferenceType;
+            if (!conferenceType && eventData.hangoutLink) {
+                conferenceType = 'meet';
+            }
+
+            let primaryLabel;
+            if (conferenceType === 'meet') {
+                primaryLabel = chrome.i18n.getMessage('joinMeet') || 'Join Meet';
+            } else if (conferenceType === 'video') {
+                primaryLabel = chrome.i18n.getMessage('joinVideoConference') || 'Join video conference';
+            } else {
+                primaryLabel = chrome.i18n.getMessage('openSideTimeTable') || 'Open SideTimeTable';
+            }
 
             // Create the notification with a fallback for icon issues
             const notificationOptions = {
@@ -160,15 +175,10 @@ export class AlarmManager {
                 title: chrome.i18n.getMessage('eventReminder') || 'Event Reminder',
                 message: chrome.i18n.getMessage('startsInMinutes', [eventData.title, reminderMinutes.toString(), eventData.startTime])
                     || `"${eventData.title}" starts in ${reminderMinutes} minutes (${eventData.startTime})`,
-                buttons: hasMeetLink
-                    ? [
-                        { title: chrome.i18n.getMessage('joinMeet') || 'Join Meet' },
-                        { title: chrome.i18n.getMessage('dismissNotification') || 'Dismiss' }
-                    ]
-                    : [
-                        { title: chrome.i18n.getMessage('openSideTimeTable') || 'Open SideTimeTable' },
-                        { title: chrome.i18n.getMessage('dismissNotification') || 'Dismiss' }
-                    ],
+                buttons: [
+                    { title: primaryLabel },
+                    { title: chrome.i18n.getMessage('dismissNotification') || 'Dismiss' }
+                ],
                 requireInteraction: true
             };
 
@@ -291,7 +301,13 @@ export class AlarmManager {
                 when: reminderTime
             });
 
-            // Store the event data for later retrieval
+            // Store the event data for later retrieval. Prefer non-Meet conference URLs
+            // (Zoom/Teams/Webex pasted into description) over auto-attached hangoutLink.
+            const videoUrl = extractVideoUrl(event);
+            const meetUrl = extractMeetUrl(event);
+            const conferenceUrl = videoUrl || meetUrl || null;
+            const conferenceType = videoUrl ? 'video' : (meetUrl ? 'meet' : null);
+
             const storageKey = `googleEventData_${alarmName}`;
             await chrome.storage.local.set({
                 [storageKey]: {
@@ -300,8 +316,8 @@ export class AlarmManager {
                     startTime: this.formatTimeFromDateTime(event.start.dateTime),
                     dateStr: dateStr,
                     reminderMinutes: reminderMinutes,
-                    // Links for quick navigation (if available)
-                    hangoutLink: event.hangoutLink || null,
+                    conferenceUrl: conferenceUrl,
+                    conferenceType: conferenceType,
                     htmlLink: event.htmlLink || null
                 }
             });

--- a/src/lib/conference-url-utils.js
+++ b/src/lib/conference-url-utils.js
@@ -7,7 +7,7 @@
  * DOMParser-based stripHtml.
  */
 
-const ENTITY_REPLACEMENTS = [
+const NAMED_ENTITY_REPLACEMENTS = [
     [/&amp;/g, '&'],
     [/&lt;/g, '<'],
     [/&gt;/g, '>'],
@@ -18,13 +18,24 @@ const ENTITY_REPLACEMENTS = [
 
 function decodeHtmlEntities(s) {
     let out = s;
-    for (const [pattern, replacement] of ENTITY_REPLACEMENTS) {
+    for (const [pattern, replacement] of NAMED_ENTITY_REPLACEMENTS) {
         out = out.replace(pattern, replacement);
     }
+    out = out.replace(/&#[xX]([0-9a-fA-F]+);/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16)));
+    out = out.replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(parseInt(dec, 10)));
     return out;
 }
 
-const URL_TAIL = `[^\\s<>"')]+`;
+// Trailing punctuation that's almost always a sentence terminator, not part of the URL.
+function trimTrailingPunctuation(url) {
+    return url.replace(/[.,;:!?。、)\]]+$/, '');
+}
+
+// ASCII URL-safe characters (RFC 3986 unreserved + sub-delims + path chars), minus
+// quote/bracket/paren that act as URL boundaries in HTML and prose. Restricting to ASCII
+// prevents the URL match from absorbing trailing Japanese text when there is no space
+// between the URL and the next sentence.
+const URL_TAIL = `[A-Za-z0-9\\-._~:/?#@!$&'*+,;=%\\[\\]]+`;
 
 const VIDEO_PATTERNS = [
     new RegExp(`https:\\/\\/[^\\s/]*zoom\\.us\\/${URL_TAIL}`, 'i'),
@@ -57,7 +68,7 @@ export function extractVideoUrl(event) {
     for (const source of sources) {
         for (const pattern of VIDEO_PATTERNS) {
             const match = source.match(pattern);
-            if (match) return match[0];
+            if (match) return trimTrailingPunctuation(match[0]);
         }
     }
     return null;

--- a/src/lib/conference-url-utils.js
+++ b/src/lib/conference-url-utils.js
@@ -1,0 +1,73 @@
+/**
+ * Conference URL extraction utilities shared between the side panel
+ * (Google event modal) and the service worker (reminder notifications).
+ *
+ * MV3 service workers do not have DOMParser, so HTML entity decoding is
+ * implemented with a small regex-based decoder rather than the side panel's
+ * DOMParser-based stripHtml.
+ */
+
+const ENTITY_REPLACEMENTS = [
+    [/&amp;/g, '&'],
+    [/&lt;/g, '<'],
+    [/&gt;/g, '>'],
+    [/&quot;/g, '"'],
+    [/&#39;/g, "'"],
+    [/&nbsp;/g, ' '],
+];
+
+function decodeHtmlEntities(s) {
+    let out = s;
+    for (const [pattern, replacement] of ENTITY_REPLACEMENTS) {
+        out = out.replace(pattern, replacement);
+    }
+    return out;
+}
+
+const URL_TAIL = `[^\\s<>"')]+`;
+
+const VIDEO_PATTERNS = [
+    new RegExp(`https:\\/\\/[^\\s/]*zoom\\.us\\/${URL_TAIL}`, 'i'),
+    new RegExp(`https:\\/\\/[^\\s/]*teams\\.microsoft\\.com\\/${URL_TAIL}`, 'i'),
+    new RegExp(`https:\\/\\/[^\\s/]*webex\\.com\\/${URL_TAIL}`, 'i'),
+];
+
+const MEET_PATTERN = /https:\/\/meet\.google\.com\/[a-z-]+/i;
+
+export function extractMeetUrl(event) {
+    const sources = [
+        event.hangoutLink,
+        event.conferenceData?.entryPoints?.find(ep => ep.entryPointType === 'video')?.uri,
+        event.description,
+        event.location,
+    ].filter(Boolean).map(decodeHtmlEntities);
+
+    for (const source of sources) {
+        const match = source.match(MEET_PATTERN);
+        if (match) return match[0];
+    }
+    return null;
+}
+
+export function extractVideoUrl(event) {
+    const sources = [event.description, event.location]
+        .filter(Boolean)
+        .map(decodeHtmlEntities);
+
+    for (const source of sources) {
+        for (const pattern of VIDEO_PATTERNS) {
+            const match = source.match(pattern);
+            if (match) return match[0];
+        }
+    }
+    return null;
+}
+
+export function selectNotificationUrl(eventData) {
+    return (
+        eventData?.conferenceUrl ||
+        eventData?.hangoutLink ||
+        eventData?.htmlLink ||
+        null
+    );
+}

--- a/src/side_panel/components/modals/google-event-content-builder.js
+++ b/src/side_panel/components/modals/google-event-content-builder.js
@@ -4,6 +4,8 @@
  * Extracts DOM-building logic from GoogleEventModal into a standalone class.
  * Methods receive DOM elements and event data as parameters, mutating the DOM directly.
  */
+import { extractMeetUrl, extractVideoUrl } from '../../../lib/conference-url-utils.js';
+
 export class GoogleEventContentBuilder {
     /**
      * Set calendar information
@@ -169,7 +171,7 @@ export class GoogleEventContentBuilder {
         meetElement.innerHTML = '';
 
         // Search for Google Meet URL
-        const meetUrl = this.extractMeetUrl(event);
+        const meetUrl = extractMeetUrl(event);
 
         if (meetUrl) {
             const icon = document.createElement('i');
@@ -186,9 +188,9 @@ export class GoogleEventContentBuilder {
             meetElement.appendChild(link);
         }
 
-        // Search for the other video conference links
-        const otherVideoUrl = this.extractVideoUrl(event);
-        if (otherVideoUrl && !meetUrl) {
+        // Search for the other video conference links - render alongside Meet when both exist
+        const otherVideoUrl = extractVideoUrl(event);
+        if (otherVideoUrl) {
             const icon = document.createElement('i');
             icon.className = 'fas fa-video me-1';
 
@@ -312,58 +314,6 @@ export class GoogleEventContentBuilder {
             attendeesElement.appendChild(icon);
             attendeesElement.appendChild(container);
         }
-    }
-
-    /**
-     * Extract Google Meet URL
-     * @param {Object} event - Google event data
-     * @returns {string|null} Meet URL or null
-     */
-    extractMeetUrl(event) {
-        const sources = [
-            event.hangoutLink,
-            event.conferenceData?.entryPoints?.find(ep => ep.entryPointType === 'video')?.uri,
-            event.description,
-            event.location
-        ].filter(Boolean);
-
-        for (const source of sources) {
-            const meetMatch = source.match(/https:\/\/meet\.google\.com\/[a-z-]+/i);
-            if (meetMatch) {
-                return meetMatch[0];
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * Extract other video conference URLs
-     * @param {Object} event - Google event data
-     * @returns {string|null} Video URL or null
-     */
-    extractVideoUrl(event) {
-        const sources = [
-            event.description,
-            event.location
-        ].filter(Boolean);
-
-        const videoPatterns = [
-            /https:\/\/.*zoom\.us\/[^\s]+/i,
-            /https:\/\/.*teams\.microsoft\.com\/[^\s]+/i,
-            /https:\/\/.*webex\.com\/[^\s]+/i
-        ];
-
-        for (const source of sources) {
-            for (const pattern of videoPatterns) {
-                const match = source.match(pattern);
-                if (match) {
-                    return match[0];
-                }
-            }
-        }
-
-        return null;
     }
 
     /**

--- a/src/side_panel/components/modals/google-event-content-builder.js
+++ b/src/side_panel/components/modals/google-event-content-builder.js
@@ -170,25 +170,8 @@ export class GoogleEventContentBuilder {
     setMeetInfo(meetElement, event) {
         meetElement.innerHTML = '';
 
-        // Search for Google Meet URL
-        const meetUrl = extractMeetUrl(event);
-
-        if (meetUrl) {
-            const icon = document.createElement('i');
-            icon.className = 'fas fa-video me-1';
-
-            const link = document.createElement('a');
-            link.href = meetUrl;
-            link.target = '_blank';
-            link.setAttribute('data-localize', '__MSG_joinGoogleMeet__');
-            link.textContent = window.getLocalizedMessage('joinGoogleMeet');
-            link.style.cssText = 'color: var(--side-calendar-link-color); text-decoration: none;';
-
-            meetElement.appendChild(icon);
-            meetElement.appendChild(link);
-        }
-
-        // Search for the other video conference links - render alongside Meet when both exist
+        // Render non-Meet video conference link first to match the notification button priority
+        // (a Zoom/Teams/Webex URL pasted in the description is treated as the user's intended room).
         const otherVideoUrl = extractVideoUrl(event);
         if (otherVideoUrl) {
             const icon = document.createElement('i');
@@ -199,6 +182,22 @@ export class GoogleEventContentBuilder {
             link.target = '_blank';
             link.setAttribute('data-localize', '__MSG_joinVideoConference__');
             link.textContent = window.getLocalizedMessage('joinVideoConference');
+            link.style.cssText = 'color: var(--side-calendar-link-color); text-decoration: none;';
+
+            meetElement.appendChild(icon);
+            meetElement.appendChild(link);
+        }
+
+        const meetUrl = extractMeetUrl(event);
+        if (meetUrl) {
+            const icon = document.createElement('i');
+            icon.className = 'fas fa-video me-1';
+
+            const link = document.createElement('a');
+            link.href = meetUrl;
+            link.target = '_blank';
+            link.setAttribute('data-localize', '__MSG_joinGoogleMeet__');
+            link.textContent = window.getLocalizedMessage('joinGoogleMeet');
             link.style.cssText = 'color: var(--side-calendar-link-color); text-decoration: none;';
 
             meetElement.appendChild(icon);

--- a/tests/lib/alarm-manager.test.js
+++ b/tests/lib/alarm-manager.test.js
@@ -200,17 +200,20 @@ describe('AlarmManager', () => {
 
     // ---------------------------------------------------------------
     // SPEC: Notification Content
-    // - hangoutLink → "Join Meet" button
-    // - no hangoutLink → "Open SideTimeTable" button
+    // - conferenceType 'meet' → "Join Meet" button
+    // - conferenceType 'video' → "Join video conference" button
+    // - no conference link → "Open SideTimeTable" button
+    // - legacy data with hangoutLink → treated as 'meet'
     // - requireInteraction: true
     // - icon fallback on failure
     // - no notification for missing event data
     // ---------------------------------------------------------------
     describe('SPEC: notification content', () => {
-        test('event with hangoutLink → first button is Join Meet', async () => {
+        test('event with conferenceType=meet → first button is Join Meet', async () => {
             const data = {
                 id: 'g1', title: 'Sync', startTime: '14:00',
-                hangoutLink: 'https://meet.google.com/abc'
+                conferenceUrl: 'https://meet.google.com/abc',
+                conferenceType: 'meet'
             };
             chrome.storage.local.set({
                 'googleEventData_google_event_reminder_2025-03-15_g1': data
@@ -219,18 +222,49 @@ describe('AlarmManager', () => {
             await AlarmManager.showReminderNotification('google_event_reminder_2025-03-15_g1');
 
             const opts = chrome.notifications.create.mock.calls[0][1];
-            expect(opts.buttons[0].title).toMatch(/Join.*Meet|Meet/i);
+            expect(opts.buttons[0].title).toMatch(/joinMeet|Join.*Meet/i);
             expect(opts.requireInteraction).toBe(true);
         });
 
-        test('event without hangoutLink → first button is Open SideTimeTable', async () => {
+        test('event with conferenceType=video → first button is Join video conference', async () => {
+            const data = {
+                id: 'g2', title: 'Zoom call', startTime: '15:00',
+                conferenceUrl: 'https://us02web.zoom.us/j/12345',
+                conferenceType: 'video'
+            };
+            chrome.storage.local.set({
+                'googleEventData_google_event_reminder_2025-03-15_g2': data
+            }, () => {});
+
+            await AlarmManager.showReminderNotification('google_event_reminder_2025-03-15_g2');
+
+            const opts = chrome.notifications.create.mock.calls[0][1];
+            expect(opts.buttons[0].title).toMatch(/joinVideoConference|Join.*video/i);
+        });
+
+        test('legacy data with hangoutLink only → treated as meet', async () => {
+            const data = {
+                id: 'g3', title: 'Old reminder', startTime: '16:00',
+                hangoutLink: 'https://meet.google.com/legacy'
+            };
+            chrome.storage.local.set({
+                'googleEventData_google_event_reminder_2025-03-15_g3': data
+            }, () => {});
+
+            await AlarmManager.showReminderNotification('google_event_reminder_2025-03-15_g3');
+
+            const opts = chrome.notifications.create.mock.calls[0][1];
+            expect(opts.buttons[0].title).toMatch(/joinMeet|Join.*Meet/i);
+        });
+
+        test('event without conference link → first button is Open SideTimeTable', async () => {
             const event = { id: 'e1', title: 'Meeting', startTime: '11:00' };
             chrome.storage.local.set({ 'localEvents_2025-03-15': [event] }, () => {});
 
             await AlarmManager.showReminderNotification('event_reminder_2025-03-15_e1');
 
             const opts = chrome.notifications.create.mock.calls[0][1];
-            expect(opts.buttons[0].title).toMatch(/Open.*SideTimeTable|SideTimeTable/i);
+            expect(opts.buttons[0].title).toMatch(/openSideTimeTable|Open.*SideTimeTable/i);
         });
 
         test('no notification when event data is missing', async () => {
@@ -256,6 +290,76 @@ describe('AlarmManager', () => {
             // Second call should not have iconUrl
             const secondOpts = chrome.notifications.create.mock.calls[1][1];
             expect(secondOpts.iconUrl).toBeUndefined();
+        });
+    });
+
+    // ---------------------------------------------------------------
+    // SPEC: setGoogleEventReminder stores conference URL/type for notifications
+    // - description-only Zoom URL → conferenceType 'video'
+    // - hangoutLink only → conferenceType 'meet'
+    // - both Zoom in description AND hangoutLink → Zoom wins (video)
+    // - no conference link → both fields null
+    // ---------------------------------------------------------------
+    describe('SPEC: setGoogleEventReminder conference URL extraction', () => {
+        const FUTURE_ISO = '2099-06-15T14:00:00Z';
+        const DATE_STR = '2099-06-15';
+
+        async function readSavedPayload(eventId) {
+            const key = `googleEventData_google_event_reminder_${DATE_STR}_${eventId}`;
+            const stored = await chrome.storage.local.get(key);
+            return stored[key];
+        }
+
+        test('description with Zoom URL → conferenceType=video, conferenceUrl=zoom', async () => {
+            await AlarmManager.setGoogleEventReminder({
+                id: 'g-zoom',
+                summary: 'Zoom call',
+                start: { dateTime: FUTURE_ISO },
+                description: 'Join here: https://us02web.zoom.us/j/9999?pwd=abc'
+            }, DATE_STR, 5);
+
+            const payload = await readSavedPayload('g-zoom');
+            expect(payload.conferenceType).toBe('video');
+            expect(payload.conferenceUrl).toBe('https://us02web.zoom.us/j/9999?pwd=abc');
+        });
+
+        test('hangoutLink only → conferenceType=meet, conferenceUrl=meet', async () => {
+            await AlarmManager.setGoogleEventReminder({
+                id: 'g-meet',
+                summary: 'Meet only',
+                start: { dateTime: FUTURE_ISO },
+                hangoutLink: 'https://meet.google.com/abc-defg-hij'
+            }, DATE_STR, 5);
+
+            const payload = await readSavedPayload('g-meet');
+            expect(payload.conferenceType).toBe('meet');
+            expect(payload.conferenceUrl).toBe('https://meet.google.com/abc-defg-hij');
+        });
+
+        test('both Zoom in description and hangoutLink → Zoom wins', async () => {
+            await AlarmManager.setGoogleEventReminder({
+                id: 'g-both',
+                summary: 'Both links',
+                start: { dateTime: FUTURE_ISO },
+                hangoutLink: 'https://meet.google.com/auto-attached',
+                description: 'Real meeting at https://us02web.zoom.us/j/123'
+            }, DATE_STR, 5);
+
+            const payload = await readSavedPayload('g-both');
+            expect(payload.conferenceType).toBe('video');
+            expect(payload.conferenceUrl).toBe('https://us02web.zoom.us/j/123');
+        });
+
+        test('no conference link → conferenceUrl and conferenceType are null', async () => {
+            await AlarmManager.setGoogleEventReminder({
+                id: 'g-bare',
+                summary: 'No link',
+                start: { dateTime: FUTURE_ISO }
+            }, DATE_STR, 5);
+
+            const payload = await readSavedPayload('g-bare');
+            expect(payload.conferenceType).toBeNull();
+            expect(payload.conferenceUrl).toBeNull();
         });
     });
 

--- a/tests/lib/conference-url-utils.test.js
+++ b/tests/lib/conference-url-utils.test.js
@@ -1,0 +1,132 @@
+/**
+ * Tests for conference-url-utils
+ */
+import {
+    extractMeetUrl,
+    extractVideoUrl,
+    selectNotificationUrl,
+} from '../../src/lib/conference-url-utils.js';
+
+describe('extractMeetUrl', () => {
+    test('hangoutLink direct', () => {
+        expect(extractMeetUrl({ hangoutLink: 'https://meet.google.com/abc-defg-hij' }))
+            .toBe('https://meet.google.com/abc-defg-hij');
+    });
+
+    test('conferenceData entryPoints (video)', () => {
+        const event = {
+            conferenceData: {
+                entryPoints: [
+                    { entryPointType: 'phone', uri: 'tel:+1234' },
+                    { entryPointType: 'video', uri: 'https://meet.google.com/xyz-pqrs-uvw' },
+                ]
+            }
+        };
+        expect(extractMeetUrl(event)).toBe('https://meet.google.com/xyz-pqrs-uvw');
+    });
+
+    test('Meet URL pasted in description', () => {
+        expect(extractMeetUrl({ description: 'Click https://meet.google.com/aaa-bbbb-ccc here' }))
+            .toBe('https://meet.google.com/aaa-bbbb-ccc');
+    });
+
+    test('Meet URL pasted in location', () => {
+        expect(extractMeetUrl({ location: 'https://meet.google.com/loc-test-xyz' }))
+            .toBe('https://meet.google.com/loc-test-xyz');
+    });
+
+    test('returns null when no Meet URL', () => {
+        expect(extractMeetUrl({ description: 'No conference link here' })).toBeNull();
+    });
+
+    test('returns null for empty event', () => {
+        expect(extractMeetUrl({})).toBeNull();
+    });
+});
+
+describe('extractVideoUrl', () => {
+    test('Zoom URL in description', () => {
+        expect(extractVideoUrl({ description: 'Join: https://us02web.zoom.us/j/12345' }))
+            .toBe('https://us02web.zoom.us/j/12345');
+    });
+
+    test('Teams URL in description', () => {
+        expect(extractVideoUrl({ description: 'https://teams.microsoft.com/l/meetup-join/abc' }))
+            .toBe('https://teams.microsoft.com/l/meetup-join/abc');
+    });
+
+    test('Webex URL in location', () => {
+        expect(extractVideoUrl({ location: 'https://company.webex.com/meet/room1' }))
+            .toBe('https://company.webex.com/meet/room1');
+    });
+
+    test('HTML-encoded ampersand in Zoom URL is decoded', () => {
+        const event = {
+            description: 'Join https://us02web.zoom.us/j/1?pwd=a&amp;tk=b end'
+        };
+        expect(extractVideoUrl(event)).toBe('https://us02web.zoom.us/j/1?pwd=a&tk=b');
+    });
+
+    test('Zoom URL inside HTML anchor stops at quote', () => {
+        const event = {
+            description: '<a href="https://zoom.us/j/777">click</a>'
+        };
+        expect(extractVideoUrl(event)).toBe('https://zoom.us/j/777');
+    });
+
+    test('does not greedily span multiple Zoom URLs', () => {
+        const event = {
+            description: 'Visit https://zoom.us/j/AAA and https://zoom.us/j/BBB'
+        };
+        expect(extractVideoUrl(event)).toBe('https://zoom.us/j/AAA');
+    });
+
+    test('does not falsely match zoom.usa.example.com', () => {
+        // The slash after zoom.us in the regex prevents matching subdomains containing zoom.usa
+        expect(extractVideoUrl({ description: 'https://zoom.usa.example.com/foo' })).toBeNull();
+    });
+
+    test('returns null when no video URL', () => {
+        expect(extractVideoUrl({ description: 'Just text', location: 'Conference Room' })).toBeNull();
+    });
+
+    test('does not match Meet URL', () => {
+        expect(extractVideoUrl({ description: 'https://meet.google.com/abc-defg-hij' })).toBeNull();
+    });
+
+    test('returns null for empty event', () => {
+        expect(extractVideoUrl({})).toBeNull();
+    });
+});
+
+describe('selectNotificationUrl', () => {
+    test('prefers conferenceUrl when set', () => {
+        expect(selectNotificationUrl({
+            conferenceUrl: 'https://us02web.zoom.us/j/1',
+            hangoutLink: 'https://meet.google.com/old',
+            htmlLink: 'https://calendar.google.com/...',
+        })).toBe('https://us02web.zoom.us/j/1');
+    });
+
+    test('falls back to hangoutLink for legacy data', () => {
+        expect(selectNotificationUrl({
+            hangoutLink: 'https://meet.google.com/legacy',
+            htmlLink: 'https://calendar.google.com/...',
+        })).toBe('https://meet.google.com/legacy');
+    });
+
+    test('falls back to htmlLink when no conference link', () => {
+        expect(selectNotificationUrl({
+            htmlLink: 'https://calendar.google.com/event?id=abc',
+        })).toBe('https://calendar.google.com/event?id=abc');
+    });
+
+    test('returns null for empty object', () => {
+        expect(selectNotificationUrl({})).toBeNull();
+    });
+
+    test('returns null for null/undefined input', () => {
+        expect(selectNotificationUrl(null)).toBeNull();
+        expect(selectNotificationUrl(undefined)).toBeNull();
+    });
+});

--- a/tests/lib/conference-url-utils.test.js
+++ b/tests/lib/conference-url-utils.test.js
@@ -81,6 +81,37 @@ describe('extractVideoUrl', () => {
         expect(extractVideoUrl(event)).toBe('https://zoom.us/j/AAA');
     });
 
+    test('strips trailing sentence punctuation', () => {
+        expect(extractVideoUrl({ description: 'Use https://zoom.us/j/123.' }))
+            .toBe('https://zoom.us/j/123');
+        expect(extractVideoUrl({ description: 'See https://zoom.us/j/456, and reply.' }))
+            .toBe('https://zoom.us/j/456');
+        expect(extractVideoUrl({ description: 'リンク: https://zoom.us/j/789。' }))
+            .toBe('https://zoom.us/j/789');
+        expect(extractVideoUrl({ description: 'click https://zoom.us/j/abc!' }))
+            .toBe('https://zoom.us/j/abc');
+        expect(extractVideoUrl({ description: 'try https://zoom.us/j/qq?' }))
+            .toBe('https://zoom.us/j/qq');
+        expect(extractVideoUrl({ description: 'see https://zoom.us/j/sc;' }))
+            .toBe('https://zoom.us/j/sc');
+        expect(extractVideoUrl({ description: 'リンク https://zoom.us/j/jp、続きあり' }))
+            .toBe('https://zoom.us/j/jp');
+    });
+
+    test('decodes numeric HTML entities', () => {
+        expect(extractVideoUrl({ description: 'https://zoom.us/j/1?pwd=a&#38;b' }))
+            .toBe('https://zoom.us/j/1?pwd=a&b');
+        expect(extractVideoUrl({ description: 'https://zoom.us/j/1?pwd=a&#x26;b' }))
+            .toBe('https://zoom.us/j/1?pwd=a&b');
+        expect(extractVideoUrl({ description: 'https://zoom.us/j/1?pwd=a&#X26;b' }))
+            .toBe('https://zoom.us/j/1?pwd=a&b');
+    });
+
+    test('multi-line description with URL on its own line', () => {
+        const event = { description: 'Agenda:\nhttps://zoom.us/j/777\nSee you there' };
+        expect(extractVideoUrl(event)).toBe('https://zoom.us/j/777');
+    });
+
     test('does not falsely match zoom.usa.example.com', () => {
         // The slash after zoom.us in the regex prevents matching subdomains containing zoom.usa
         expect(extractVideoUrl({ description: 'https://zoom.usa.example.com/foo' })).toBeNull();

--- a/tests/side_panel/google-event-content-builder.test.js
+++ b/tests/side_panel/google-event-content-builder.test.js
@@ -1,0 +1,89 @@
+/**
+ * Tests for GoogleEventContentBuilder.setMeetInfo() rendering order.
+ *
+ * Locks in that the non-Meet video link is rendered before the Meet link
+ * when both are present, matching the notification button priority
+ * (video > meet) in alarm-manager / selectNotificationUrl.
+ */
+
+function makeMockElement() {
+    const children = [];
+    return {
+        tagName: 'DIV',
+        className: '',
+        style: { cssText: '' },
+        href: '',
+        target: '',
+        textContent: '',
+        children,
+        innerHTML: '',
+        appendChild(child) { children.push(child); return child; },
+        setAttribute() {},
+    };
+}
+
+beforeEach(() => {
+    global.document = {
+        createElement: () => makeMockElement(),
+    };
+    global.window.getLocalizedMessage = (key) => key;
+});
+
+afterEach(() => {
+    delete global.document;
+    delete global.window.getLocalizedMessage;
+});
+
+describe('GoogleEventContentBuilder.setMeetInfo render order', () => {
+    test('renders non-Meet video link before Meet link when both exist', async () => {
+        const { GoogleEventContentBuilder } = await import('../../src/side_panel/components/modals/google-event-content-builder.js');
+        const builder = new GoogleEventContentBuilder();
+        const meetElement = makeMockElement();
+
+        builder.setMeetInfo(meetElement, {
+            hangoutLink: 'https://meet.google.com/abc-defg-hij',
+            description: 'Backup: https://us02web.zoom.us/j/42',
+        });
+
+        // 4 children: [videoIcon, videoLink, meetIcon, meetLink]
+        expect(meetElement.children).toHaveLength(4);
+        expect(meetElement.children[1].href).toBe('https://us02web.zoom.us/j/42');
+        expect(meetElement.children[3].href).toBe('https://meet.google.com/abc-defg-hij');
+    });
+
+    test('renders only video link when no Meet URL', async () => {
+        const { GoogleEventContentBuilder } = await import('../../src/side_panel/components/modals/google-event-content-builder.js');
+        const builder = new GoogleEventContentBuilder();
+        const meetElement = makeMockElement();
+
+        builder.setMeetInfo(meetElement, {
+            description: 'https://us02web.zoom.us/j/77',
+        });
+
+        expect(meetElement.children).toHaveLength(2);
+        expect(meetElement.children[1].href).toBe('https://us02web.zoom.us/j/77');
+    });
+
+    test('renders only Meet link when no other video URL', async () => {
+        const { GoogleEventContentBuilder } = await import('../../src/side_panel/components/modals/google-event-content-builder.js');
+        const builder = new GoogleEventContentBuilder();
+        const meetElement = makeMockElement();
+
+        builder.setMeetInfo(meetElement, {
+            hangoutLink: 'https://meet.google.com/abc-defg-hij',
+        });
+
+        expect(meetElement.children).toHaveLength(2);
+        expect(meetElement.children[1].href).toBe('https://meet.google.com/abc-defg-hij');
+    });
+
+    test('renders nothing when no conference URL', async () => {
+        const { GoogleEventContentBuilder } = await import('../../src/side_panel/components/modals/google-event-content-builder.js');
+        const builder = new GoogleEventContentBuilder();
+        const meetElement = makeMockElement();
+
+        builder.setMeetInfo(meetElement, { description: 'No links here' });
+
+        expect(meetElement.children).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
## Summary
Refactors conference URL extraction logic into a shared utility module (`conference-url-utils.js`) to support both the side panel and service worker. This enables consistent handling of Google Meet, Zoom, Teams, and Webex URLs across the extension, with proper HTML entity decoding and URL validation.

## Key Changes

- **New module: `src/lib/conference-url-utils.js`**
  - `extractMeetUrl()`: Detects Google Meet URLs from hangoutLink, conferenceData, description, or location
  - `extractVideoUrl()`: Detects Zoom/Teams/Webex URLs with HTML entity decoding and trailing punctuation trimming
  - `selectNotificationUrl()`: Prioritizes conference URL over fallback links for notifications
  - Implements regex-based HTML entity decoder (no DOMParser dependency for MV3 service workers)

- **Updated `src/side_panel/components/modals/google-event-content-builder.js`**
  - Removed duplicate `extractMeetUrl()` and `extractVideoUrl()` methods
  - Now imports and uses shared utilities from `conference-url-utils.js`
  - Reordered rendering to show non-Meet video links before Meet links (matches notification priority)

- **Updated `src/lib/alarm-manager.js`**
  - Extracts and stores `conferenceUrl` and `conferenceType` when setting Google event reminders
  - Prioritizes user-pasted video URLs (Zoom/Teams/Webex) over auto-attached hangoutLink
  - Updated notification button logic to use `conferenceType` field ('meet', 'video', or null)
  - Maintains backward compatibility with legacy reminder data containing only `hangoutLink`

- **Updated `src/background.js`**
  - Imports `selectNotificationUrl` for consistent URL selection in notification handling

## Notable Implementation Details

- **HTML Entity Decoding**: Implements named entity replacements and numeric entity decoding (decimal and hex) without DOMParser, enabling service worker compatibility
- **URL Validation**: Uses precise regex patterns with domain boundary checks (e.g., `zoom.us/` prevents false matches on `zoom.usa.example.com`)
- **Punctuation Handling**: Strips trailing sentence punctuation (`.!?,;:。、`) that commonly appears after URLs in prose
- **Priority System**: Video conference URLs (Zoom/Teams/Webex) take precedence over Google Meet when both are present, reflecting user intent when manually pasting URLs
- **Backward Compatibility**: Legacy reminders with only `hangoutLink` are automatically treated as 'meet' type

## Test Coverage
- Comprehensive test suite for URL extraction (`tests/lib/conference-url-utils.test.js`)
- Updated alarm manager tests to verify conference type detection and storage
- New side panel tests verifying correct rendering order when both video and Meet links exist

https://claude.ai/code/session_01Xkyfj661tUuyWgXZbnoudy