### PR TITLE
Preserve line breaks when stripping HTML from Google Calendar events

### DIFF
--- a/src/side_panel/components/modals/google-event-content-builder.js
+++ b/src/side_panel/components/modals/google-event-content-builder.js
@@ -352,12 +352,17 @@ export class GoogleEventContentBuilder {
     }
 
     /**
-     * Remove HTML tags
+     * Remove HTML tags while preserving line breaks from <br> and block elements.
+     * Google Calendar stores rich descriptions as HTML, so raw textContent would
+     * collapse all whitespace and drop newlines.
      * @param {string} html - HTML string
-     * @returns {string} Plain text
+     * @returns {string} Plain text with newline characters preserved
      */
     stripHtml(html) {
         const doc = new DOMParser().parseFromString(html, 'text/html');
-        return doc.body.textContent || '';
+        doc.body.querySelectorAll('br').forEach(br => br.replaceWith('\n'));
+        doc.body.querySelectorAll('p, div, li, tr, h1, h2, h3, h4, h5, h6, blockquote, pre')
+            .forEach(el => el.append('\n'));
+        return (doc.body.textContent || '').replace(/\n{3,}/g, '\n\n').replace(/^\n+|\n+$/g, '');
     }
 }


### PR DESCRIPTION
## Summary
Improved the `stripHtml()` method in the Google Event Content Builder to preserve line breaks and formatting when converting HTML descriptions to plain text. This ensures that Google Calendar's rich text descriptions maintain their intended structure and readability.

## Key Changes
- Modified `stripHtml()` to convert `<br>` tags to newline characters instead of discarding them
- Added handling for block-level elements (p, div, li, tr, h1-h6, blockquote, pre) by appending newlines after them
- Implemented normalization to collapse excessive blank lines (3+ newlines reduced to 2) and trim leading/trailing whitespace
- Updated JSDoc comments to clarify the method's behavior and explain why raw `textContent` is insufficient

## Implementation Details
The solution uses DOM parsing to intelligently handle HTML structure:
1. Parses HTML into a DOM tree using `DOMParser`
2. Replaces `<br>` elements with literal newline characters
3. Appends newlines after block-level elements to preserve document structure
4. Normalizes the resulting text to remove excessive whitespace while maintaining intentional line breaks
5. Trims leading and trailing newlines for clean output

This approach preserves the semantic structure of Google Calendar descriptions while converting them to readable plain text.

https://claude.ai/code/session_01MCNN7ixM3YcdLUiSuzGopE