### PR TITLE
Handle full-day OOO events with dateTime format as all-day

### DIFF
--- a/src/side_panel/event-handlers.js
+++ b/src/side_panel/event-handlers.js
@@ -13,6 +13,35 @@ import {getDemoEvents, getDemoLocalEvents, isDemoMode} from '../lib/demo-data.js
 import { GoogleEventRenderer } from './google-event-renderer.js';
 import { LocalEventRenderer } from './local-event-renderer.js';
 
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Detect events that should be rendered as all-day chips.
+ *
+ * Returns true for the standard date-only format, and for OOO events that
+ * Google Calendar returns with dateTime but which span a full day starting
+ * at local midnight (Google's OOO UI uses time ranges, so "out for the day"
+ * comes back as 00:00 → 24:00 timed events).
+ *
+ * @param {Object} event
+ * @returns {boolean}
+ */
+export function isAllDayLikeEvent(event) {
+    if (!event || !event.start || !event.end) return false;
+    if (event.start.date || event.end.date) return true;
+
+    if (event.eventType === 'outOfOffice' && event.start.dateTime && event.end.dateTime) {
+        const start = new Date(event.start.dateTime);
+        const end = new Date(event.end.dateTime);
+        if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return false;
+        const startsAtLocalMidnight =
+            start.getHours() === 0 && start.getMinutes() === 0 && start.getSeconds() === 0;
+        return startsAtLocalMidnight && (end.getTime() - start.getTime()) >= MS_PER_DAY;
+    }
+
+    return false;
+}
+
 /**
  * GoogleEventManager - The Google event management class
  */
@@ -291,7 +320,7 @@ export class GoogleEventManager {
                     case 'outOfOffice':
                     default: {
                         const isOOO = event.eventType === 'outOfOffice';
-                        const isAllDay = event.start.date || event.end.date;
+                        const isAllDay = isAllDayLikeEvent(event);
 
                         if (isAllDay) {
                             const result = this._renderer.createAllDayEventElement(

--- a/tests/side_panel/event-handlers-allday.test.js
+++ b/tests/side_panel/event-handlers-allday.test.js
@@ -154,6 +154,57 @@ describe('GoogleEventManager — all-day event routing', () => {
     expect(chip.textContent).toBe('Out of office');
   });
 
+  test('full-day outOfOffice event with dateTime (00:00→24:00) is routed to the all-day container', async () => {
+    // Google Calendar's OOO UI uses time ranges; "out for the day" comes back
+    // as a timed event spanning local midnight to midnight.
+    const start = new Date(2025, 5, 1, 0, 0, 0);
+    const end = new Date(2025, 5, 2, 0, 0, 0);
+    await manager._processEvents([{
+      id: 'ooo-fullday',
+      summary: 'Out of office',
+      start: { dateTime: start.toISOString() },
+      end: { dateTime: end.toISOString() },
+      eventType: 'outOfOffice',
+      calendarId: 'primary',
+    }]);
+
+    expect(allDayContainer.appendChild).toHaveBeenCalledTimes(1);
+    const chip = allDayContainer.appendChild.mock.calls[0][0];
+    expect(chip.className).toBe('all-day-event-chip all-day-event-chip-ooo');
+  });
+
+  test('partial-day outOfOffice event with dateTime stays in the timed timeline', async () => {
+    // 13:00–18:00 OOO should NOT become a chip.
+    const start = new Date(2025, 5, 1, 13, 0, 0);
+    const end = new Date(2025, 5, 1, 18, 0, 0);
+    await manager._processEvents([{
+      id: 'ooo-partial',
+      summary: 'Out of office',
+      start: { dateTime: start.toISOString() },
+      end: { dateTime: end.toISOString() },
+      eventType: 'outOfOffice',
+      calendarId: 'primary',
+    }]);
+
+    expect(allDayContainer.appendChild).not.toHaveBeenCalled();
+  });
+
+  test('full-day non-OOO event with dateTime stays in the timed timeline', async () => {
+    // Only OOO gets the dateTime→all-day promotion; a regular 24h event remains timed.
+    const start = new Date(2025, 5, 1, 0, 0, 0);
+    const end = new Date(2025, 5, 2, 0, 0, 0);
+    await manager._processEvents([{
+      id: 'long-default',
+      summary: 'Long task',
+      start: { dateTime: start.toISOString() },
+      end: { dateTime: end.toISOString() },
+      eventType: 'default',
+      calendarId: 'primary',
+    }]);
+
+    expect(allDayContainer.appendChild).not.toHaveBeenCalled();
+  });
+
   test('timed event does NOT create a chip in the all-day container', async () => {
     await manager._processEvents([timedEvent()]);
 


### PR DESCRIPTION
## Summary
Google Calendar's out-of-office (OOO) UI returns full-day OOO events as timed events spanning midnight to midnight (00:00 → 24:00) rather than using the standard all-day date format. This PR adds logic to detect and properly route these events to the all-day container.

## Key Changes
- **New `isAllDayLikeEvent()` function**: Detects events that should render as all-day chips, including:
  - Standard all-day events with `date` fields
  - OOO events with `dateTime` that span a full day starting at local midnight
  
- **Updated event routing logic**: Changed the all-day detection in `GoogleEventManager._processEvents()` to use the new `isAllDayLikeEvent()` function instead of only checking for `date` fields

- **Added comprehensive test coverage**:
  - Full-day OOO events with dateTime are routed to all-day container
  - Partial-day OOO events remain in timed timeline
  - Full-day non-OOO events remain in timed timeline (only OOO gets this special handling)

## Implementation Details
The solution specifically targets OOO events because Google Calendar's OOO UI uses time ranges to represent "out for the day" scenarios. The detection validates that:
1. The event is marked as `eventType: 'outOfOffice'`
2. Both start and end use `dateTime` format (not `date`)
3. Start time is at local midnight (00:00:00)
4. Duration is at least 24 hours

This ensures regular timed events are not incorrectly promoted to all-day status.

https://claude.ai/code/session_01993JsYWTWpcVtaun1eSBgN