### PR TITLE
Serialize calendar selection mutations to prevent race conditions

### DIFF
--- a/src/side_panel/components/timeline/timeline-calendar-filter.js
+++ b/src/side_panel/components/timeline/timeline-calendar-filter.js
@@ -282,49 +282,7 @@ export class TimelineCalendarFilter extends Component {
         loading.textContent = this.getMessage('calendarFilterLoading');
         this.dropdown.appendChild(loading);
 
-        try {
-            const requestId = `filter-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-            const [response, selectedIds, groups] = await Promise.all([
-                sendMessage({ action: 'getCalendarList', requestId }),
-                loadSelectedCalendars(),
-                isDemoMode() ? getDemoCalendarGroups() : loadCalendarGroups()
-            ]);
-
-            // Bail out if dropdown was closed while fetching
-            if (!this.isOpen) return;
-
-            if (response.error || !response.calendars) {
-                this.dropdown.innerHTML = '';
-                this.refreshBtn = null;
-                this.searchInput = null;
-                this.calendarList = null;
-                const errorEl = document.createElement('div');
-                errorEl.className = 'timeline-calendar-filter-status';
-                errorEl.setAttribute('role', 'status');
-                errorEl.textContent = this.getMessage('calendarFilterError');
-                this.dropdown.appendChild(errorEl);
-                return;
-            }
-
-            this.calendars = response.calendars;
-            this.selectedIds = selectedIds;
-            this.calendarGroups = Array.isArray(groups) ? groups : [];
-
-            // Ensure primary calendar is always included in selection
-            const primary = this.calendars.find(c => c.primary);
-            if (primary && !this.selectedIds.includes(primary.id)) {
-                this.selectedIds.unshift(primary.id);
-                try {
-                    await saveSelectedCalendars(this.selectedIds);
-                } catch {
-                    // Non-critical: primary will be re-added on next open
-                }
-            }
-
-            if (!this.isOpen) return;
-            this.hasFetched = true;
-            this._renderDropdownContent();
-        } catch {
+        const showError = () => {
             this.dropdown.innerHTML = '';
             this.refreshBtn = null;
             this.searchInput = null;
@@ -334,6 +292,51 @@ export class TimelineCalendarFilter extends Component {
             errorEl.setAttribute('role', 'status');
             errorEl.textContent = this.getMessage('calendarFilterError');
             this.dropdown.appendChild(errorEl);
+        };
+
+        try {
+            const requestId = `filter-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+            const response = await sendMessage({ action: 'getCalendarList', requestId });
+
+            // Bail out if dropdown was closed while fetching
+            if (!this.isOpen) return;
+
+            if (response.error || !response.calendars) {
+                showError();
+                return;
+            }
+
+            // Apply the calendar/selection state through the op queue so a
+            // concurrent toggle's in-flight save cannot be observed
+            // half-written (which would desync the rendered checkboxes).
+            await this._enqueue(async () => {
+                const [selectedIds, groups] = await Promise.all([
+                    loadSelectedCalendars(),
+                    isDemoMode() ? getDemoCalendarGroups() : loadCalendarGroups()
+                ]);
+                if (!this.isOpen) return;
+
+                this.calendars = response.calendars;
+                this.selectedIds = selectedIds;
+                this.calendarGroups = Array.isArray(groups) ? groups : [];
+
+                // Ensure primary calendar is always included in selection
+                const primary = this.calendars.find(c => c.primary);
+                if (primary && !this.selectedIds.includes(primary.id)) {
+                    this.selectedIds.unshift(primary.id);
+                    try {
+                        await saveSelectedCalendars(this.selectedIds);
+                    } catch {
+                        // Non-critical: primary will be re-added on next open
+                    }
+                }
+
+                if (!this.isOpen) return;
+                this.hasFetched = true;
+                this._renderDropdownContent();
+            });
+        } catch {
+            showError();
         }
     }
 

--- a/src/side_panel/components/timeline/timeline-calendar-filter.js
+++ b/src/side_panel/components/timeline/timeline-calendar-filter.js
@@ -42,6 +42,7 @@ export class TimelineCalendarFilter extends Component {
         // not interleave their save/rollback steps, which would produce
         // out-of-order storage writes or a rollback clobbering a later change.
         this._opQueue = Promise.resolve();
+        this._destroyed = false;
 
         // Renderer delegate
         this.renderer = new CalendarFilterRenderer({
@@ -356,7 +357,11 @@ export class TimelineCalendarFilter extends Component {
      * @private
      */
     _enqueue(taskFn) {
-        const result = this._opQueue.then(taskFn, taskFn);
+        // Skip a queued task entirely once destroyed: its post-destroy state
+        // (selectedIds === [], renderer === null) would otherwise persist an
+        // empty selection and crash on the renderer.
+        const guarded = () => (this._destroyed ? undefined : taskFn());
+        const result = this._opQueue.then(guarded, guarded);
         // Keep the chain alive even if a task throws.
         this._opQueue = result.then(() => {}, () => {});
         return result;
@@ -415,6 +420,7 @@ export class TimelineCalendarFilter extends Component {
 
             try {
                 await saveSelectedCalendars(this.selectedIds);
+                if (this._destroyed) return;
                 this.renderer.renderCalendarList(
                     this.calendars, this.selectedIds, this.calendarGroups, this.searchTerm
                 );
@@ -425,7 +431,7 @@ export class TimelineCalendarFilter extends Component {
                 }
             } catch {
                 this.selectedIds = previousIds;
-                this.renderer.renderCalendarList(
+                this.renderer?.renderCalendarList(
                     this.calendars, this.selectedIds, this.calendarGroups, this.searchTerm
                 );
             }
@@ -473,6 +479,7 @@ export class TimelineCalendarFilter extends Component {
 
             try {
                 await saveSelectedCalendars(this.selectedIds);
+                if (this._destroyed) return;
                 // Update group header checkbox states
                 this.renderer.updateGroupCheckboxStates(
                     this.calendarList, this.calendars, this.selectedIds, this.calendarGroups
@@ -485,7 +492,7 @@ export class TimelineCalendarFilter extends Component {
                 }
             } catch {
                 this.selectedIds = previousIds;
-                this.renderer.renderCalendarList(
+                this.renderer?.renderCalendarList(
                     this.calendars, this.selectedIds, this.calendarGroups, this.searchTerm
                 );
             }
@@ -503,6 +510,8 @@ export class TimelineCalendarFilter extends Component {
      * Clean up resources
      */
     destroy() {
+        this._destroyed = true;
+        this.isOpen = false;
         if (this._rafId) {
             window.cancelAnimationFrame(this._rafId);
             this._rafId = null;

--- a/src/side_panel/components/timeline/timeline-calendar-filter.js
+++ b/src/side_panel/components/timeline/timeline-calendar-filter.js
@@ -38,6 +38,11 @@ export class TimelineCalendarFilter extends Component {
         this._rafId = null;
         this._isFetching = false;
 
+        // Serializes selection mutations: rapid or bulk (group) toggles must
+        // not interleave their save/rollback steps, which would produce
+        // out-of-order storage writes or a rollback clobbering a later change.
+        this._opQueue = Promise.resolve();
+
         // Renderer delegate
         this.renderer = new CalendarFilterRenderer({
             onSearchInput: (value) => {
@@ -207,32 +212,35 @@ export class TimelineCalendarFilter extends Component {
             if (!this.isOpen) return;
             this._focusDropdown();
         } else {
-            // Refresh selected state and groups each time
+            // Refresh selected state and groups each time. Run through the
+            // op queue so the reload observes a settled state rather than
+            // racing a toggle's in-flight save.
             this._isFetching = true;
             try {
-                const [selectedIds, groups] = await Promise.all([
-                    loadSelectedCalendars(),
-                    isDemoMode() ? getDemoCalendarGroups() : loadCalendarGroups()
-                ]);
-                if (!this.isOpen) return;
-                this.selectedIds = selectedIds;
-                this.calendarGroups = Array.isArray(groups) ? groups : [];
-                // Ensure primary calendar stays in selection
-                const primary = this.calendars.find(c => c.primary);
-                if (primary && !this.selectedIds.includes(primary.id)) {
-                    this.selectedIds.unshift(primary.id);
-                    try {
-                        await saveSelectedCalendars(this.selectedIds);
-                    } catch {
-                        // Non-critical: primary will be re-added on next open
+                await this._enqueue(async () => {
+                    const [selectedIds, groups] = await Promise.all([
+                        loadSelectedCalendars(),
+                        isDemoMode() ? getDemoCalendarGroups() : loadCalendarGroups()
+                    ]);
+                    if (!this.isOpen) return;
+                    this.selectedIds = selectedIds;
+                    this.calendarGroups = Array.isArray(groups) ? groups : [];
+                    // Ensure primary calendar stays in selection
+                    const primary = this.calendars.find(c => c.primary);
+                    if (primary && !this.selectedIds.includes(primary.id)) {
+                        this.selectedIds.unshift(primary.id);
+                        try {
+                            await saveSelectedCalendars(this.selectedIds);
+                        } catch {
+                            // Non-critical: primary will be re-added on next open
+                        }
                     }
-                }
-                if (!this.isOpen) return;
-                this._renderDropdownContent();
-                this._focusDropdown();
+                    if (!this.isOpen) return;
+                    this._renderDropdownContent();
+                    this._focusDropdown();
+                });
             } catch {
-                if (!this.isOpen) return;
-                this._renderDropdownContent();
+                if (this.isOpen) this._renderDropdownContent();
             } finally {
                 this._isFetching = false;
             }
@@ -342,66 +350,86 @@ export class TimelineCalendarFilter extends Component {
     }
 
     /**
+     * Run a selection-mutating task serially. Tasks are chained so concurrent
+     * toggles cannot interleave their compute/save/rollback steps; each task
+     * therefore observes the fully-settled state of the one before it.
+     * @private
+     */
+    _enqueue(taskFn) {
+        const result = this._opQueue.then(taskFn, taskFn);
+        // Keep the chain alive even if a task throws.
+        this._opQueue = result.then(() => {}, () => {});
+        return result;
+    }
+
+    /**
      * Handle group toggle in the filter dropdown
      * @private
      */
     async _handleGroupToggle(group, _calendars, checked) {
         if (group.calendarIds.length === 0) return;
 
-        const previousIds = [...this.selectedIds];
-        const primaryId = this.calendars.find(c => c.primary)?.id;
-        // Use full group membership (not the filtered view) for toggling
-        const fullGroupCalIds = new Set(group.calendarIds);
+        return this._enqueue(async () => {
+            // Snapshot inside the queued task so it reflects any prior toggle.
+            const previousIds = [...this.selectedIds];
+            const primaryId = this.calendars.find(c => c.primary)?.id;
+            // Use full group membership (not the filtered view) for toggling
+            const fullGroupCalIds = new Set(group.calendarIds);
+            let nextIds;
 
-        if (checked) {
-            const validCalIds = new Set(this.calendars.map(c => c.id));
-            for (const calId of group.calendarIds) {
-                if (validCalIds.has(calId) && !this.selectedIds.includes(calId)) {
-                    this.selectedIds.push(calId);
+            if (checked) {
+                nextIds = [...this.selectedIds];
+                const validCalIds = new Set(this.calendars.map(c => c.id));
+                for (const calId of group.calendarIds) {
+                    if (validCalIds.has(calId) && !nextIds.includes(calId)) {
+                        nextIds.push(calId);
+                    }
                 }
-            }
-        } else {
-            // Only preserve calendars whose sibling group is *fully* checked.
-            // A merely "selected" sibling member is not enough: it may itself
-            // be selected only via the group we are unchecking now.
-            const validCalIds = new Set(this.calendars.map(c => c.id));
-            const selectedSet = new Set(this.selectedIds);
-            const otherGroupIds = new Set();
-            for (const g of this.calendarGroups) {
-                if (g.id === group.id) continue;
-                const memberIds = g.calendarIds.filter(id => validCalIds.has(id));
-                if (memberIds.length === 0) continue;
-                const fullyChecked = memberIds.every(id => selectedSet.has(id));
-                if (!fullyChecked) continue;
-                for (const id of memberIds) {
-                    otherGroupIds.add(id);
+            } else {
+                // Only preserve calendars whose sibling group is *fully* checked.
+                // A merely "selected" sibling member is not enough: it may itself
+                // be selected only via the group we are unchecking now.
+                const validCalIds = new Set(this.calendars.map(c => c.id));
+                const selectedSet = new Set(this.selectedIds);
+                const otherGroupIds = new Set();
+                for (const g of this.calendarGroups) {
+                    if (g.id === group.id) continue;
+                    const memberIds = g.calendarIds.filter(id => validCalIds.has(id));
+                    if (memberIds.length === 0) continue;
+                    const fullyChecked = memberIds.every(id => selectedSet.has(id));
+                    if (!fullyChecked) continue;
+                    for (const id of memberIds) {
+                        otherGroupIds.add(id);
+                    }
                 }
+
+                nextIds = this.selectedIds.filter(id => {
+                    if (id === primaryId) return true;
+                    if (!fullGroupCalIds.has(id)) return true;
+                    if (otherGroupIds.has(id)) return true;
+                    return false;
+                });
             }
 
-            this.selectedIds = this.selectedIds.filter(id => {
-                if (id === primaryId) return true;
-                if (!fullGroupCalIds.has(id)) return true;
-                if (otherGroupIds.has(id)) return true;
-                return false;
-            });
-        }
+            this.selectedIds = nextIds;
 
-        try {
-            await saveSelectedCalendars(this.selectedIds);
-            this.renderer.renderCalendarList(
-                this.calendars, this.selectedIds, this.calendarGroups, this.searchTerm
-            );
-            if (this.onCalendarChange) {
-                const addedIds = this.selectedIds.filter(id => !previousIds.includes(id));
-                const removedIds = previousIds.filter(id => !this.selectedIds.includes(id));
-                this.onCalendarChange({ addedIds, removedIds });
+            try {
+                await saveSelectedCalendars(this.selectedIds);
+                this.renderer.renderCalendarList(
+                    this.calendars, this.selectedIds, this.calendarGroups, this.searchTerm
+                );
+                if (this.onCalendarChange) {
+                    const addedIds = this.selectedIds.filter(id => !previousIds.includes(id));
+                    const removedIds = previousIds.filter(id => !this.selectedIds.includes(id));
+                    this.onCalendarChange({ addedIds, removedIds });
+                }
+            } catch {
+                this.selectedIds = previousIds;
+                this.renderer.renderCalendarList(
+                    this.calendars, this.selectedIds, this.calendarGroups, this.searchTerm
+                );
             }
-        } catch {
-            this.selectedIds = previousIds;
-            this.renderer.renderCalendarList(
-                this.calendars, this.selectedIds, this.calendarGroups, this.searchTerm
-            );
-        }
+        });
     }
 
     /**
@@ -431,34 +459,37 @@ export class TimelineCalendarFilter extends Component {
      * @private
      */
     async _handleToggle(calendarId, checked) {
-        const previousIds = [...this.selectedIds];
+        return this._enqueue(async () => {
+            // Snapshot inside the queued task so it reflects any prior toggle.
+            const previousIds = [...this.selectedIds];
 
-        if (checked) {
-            if (!this.selectedIds.includes(calendarId)) {
-                this.selectedIds.push(calendarId);
+            if (checked) {
+                this.selectedIds = this.selectedIds.includes(calendarId)
+                    ? [...this.selectedIds]
+                    : [...this.selectedIds, calendarId];
+            } else {
+                this.selectedIds = this.selectedIds.filter(id => id !== calendarId);
             }
-        } else {
-            this.selectedIds = this.selectedIds.filter(id => id !== calendarId);
-        }
 
-        try {
-            await saveSelectedCalendars(this.selectedIds);
-            // Update group header checkbox states
-            this.renderer.updateGroupCheckboxStates(
-                this.calendarList, this.calendars, this.selectedIds, this.calendarGroups
-            );
-            if (this.onCalendarChange) {
-                this.onCalendarChange({
-                    addedIds: checked ? [calendarId] : [],
-                    removedIds: checked ? [] : [calendarId]
-                });
+            try {
+                await saveSelectedCalendars(this.selectedIds);
+                // Update group header checkbox states
+                this.renderer.updateGroupCheckboxStates(
+                    this.calendarList, this.calendars, this.selectedIds, this.calendarGroups
+                );
+                if (this.onCalendarChange) {
+                    this.onCalendarChange({
+                        addedIds: checked ? [calendarId] : [],
+                        removedIds: checked ? [] : [calendarId]
+                    });
+                }
+            } catch {
+                this.selectedIds = previousIds;
+                this.renderer.renderCalendarList(
+                    this.calendars, this.selectedIds, this.calendarGroups, this.searchTerm
+                );
             }
-        } catch {
-            this.selectedIds = previousIds;
-            this.renderer.renderCalendarList(
-                this.calendars, this.selectedIds, this.calendarGroups, this.searchTerm
-            );
-        }
+        });
     }
 
     /**

--- a/tests/side_panel/timeline-calendar-filter.test.js
+++ b/tests/side_panel/timeline-calendar-filter.test.js
@@ -186,4 +186,17 @@ describe('TimelineCalendarFilter — concurrent toggle serialization', () => {
     const lastSaved = saveSelectedCalendars.mock.calls.at(-1)[0];
     expect([...lastSaved].sort()).toEqual(['cal-x', 'cal-y', 'cal-z']);
   });
+
+  test('a toggle queued before destroy never persists a post-destroy state', async () => {
+    // destroy() clears selectedIds; a queued task that still ran would
+    // overwrite the stored selection with [].
+    const { filter } = buildFilter({ selectedIds: ['cal-x'], groups: [] });
+    filter.renderer = { renderCalendarList: jest.fn(), updateGroupCheckboxStates: jest.fn() };
+
+    const p = filter._handleToggle('cal-y', true);
+    filter.destroy();
+    await p;
+
+    expect(saveSelectedCalendars).not.toHaveBeenCalled();
+  });
 });

--- a/tests/side_panel/timeline-calendar-filter.test.js
+++ b/tests/side_panel/timeline-calendar-filter.test.js
@@ -34,7 +34,8 @@ beforeAll(() => {
 });
 
 import { TimelineCalendarFilter } from '../../src/side_panel/components/timeline/timeline-calendar-filter.js';
-import { saveSelectedCalendars } from '../../src/lib/settings-storage.js';
+import { saveSelectedCalendars, loadSelectedCalendars, loadCalendarGroups } from '../../src/lib/settings-storage.js';
+import { sendMessage } from '../../src/lib/chrome-messaging.js';
 
 const CAL_X = { id: 'cal-x', summary: 'X', primary: false };
 const CAL_Y = { id: 'cal-y', summary: 'Y', primary: false };
@@ -198,5 +199,39 @@ describe('TimelineCalendarFilter — concurrent toggle serialization', () => {
     await p;
 
     expect(saveSelectedCalendars).not.toHaveBeenCalled();
+  });
+
+  test('_fetchCalendars reloads only after a queued toggle save completes', async () => {
+    // A refresh fired during a toggle must not read storage mid-write.
+    const order = [];
+    saveSelectedCalendars.mockImplementation(() => {
+      order.push('save');
+      return Promise.resolve();
+    });
+    loadSelectedCalendars.mockImplementation(() => {
+      order.push('load');
+      return Promise.resolve(['cal-x']);
+    });
+    loadCalendarGroups.mockResolvedValue([]);
+    sendMessage.mockResolvedValue({ calendars: [CAL_X] });
+
+    const filter = new TimelineCalendarFilter({});
+    filter.calendars = [CAL_X];
+    filter.selectedIds = [];
+    filter.calendarGroups = [];
+    filter.isOpen = true;
+    filter.dropdown = { innerHTML: '', appendChild: jest.fn() };
+    filter.renderer = {
+      renderCalendarList: jest.fn(),
+      updateGroupCheckboxStates: jest.fn(),
+      renderDropdownContent: jest.fn(() => ({})),
+    };
+
+    const pToggle = filter._handleToggle('cal-x', true);
+    const pFetch = filter._fetchCalendars();
+    await Promise.all([pToggle, pFetch]);
+
+    expect(order.indexOf('save')).toBeGreaterThanOrEqual(0);
+    expect(order.indexOf('load')).toBeGreaterThan(order.indexOf('save'));
   });
 });

--- a/tests/side_panel/timeline-calendar-filter.test.js
+++ b/tests/side_panel/timeline-calendar-filter.test.js
@@ -137,3 +137,53 @@ describe('TimelineCalendarFilter._handleGroupToggle', () => {
     expect(onCalendarChange).not.toHaveBeenCalled();
   });
 });
+
+describe('TimelineCalendarFilter — concurrent toggle serialization', () => {
+  beforeEach(() => {
+    saveSelectedCalendars.mockClear();
+    saveSelectedCalendars.mockResolvedValue(undefined);
+  });
+
+  test('rapid concurrent single toggles end in a consistent state', async () => {
+    const { filter } = buildFilter({ selectedIds: [], groups: [] });
+    filter.renderer = { renderCalendarList: jest.fn(), updateGroupCheckboxStates: jest.fn() };
+
+    // Fire both toggles before either save resolves.
+    const p1 = filter._handleToggle('cal-x', true);
+    const p2 = filter._handleToggle('cal-y', true);
+    await Promise.all([p1, p2]);
+
+    expect([...filter.selectedIds].sort()).toEqual(['cal-x', 'cal-y']);
+    // The final persisted snapshot must contain both calendars — i.e. the
+    // second save did not race ahead of (or get clobbered by) the first.
+    const lastSaved = saveSelectedCalendars.mock.calls.at(-1)[0];
+    expect([...lastSaved].sort()).toEqual(['cal-x', 'cal-y']);
+  });
+
+  test('a failed earlier save does not clobber a later toggle', async () => {
+    saveSelectedCalendars
+      .mockRejectedValueOnce(new Error('boom'))   // first queued op fails
+      .mockResolvedValue(undefined);              // later ops succeed
+    const { filter } = buildFilter({ selectedIds: [], groups: [] });
+    filter.renderer = { renderCalendarList: jest.fn(), updateGroupCheckboxStates: jest.fn() };
+
+    const p1 = filter._handleToggle('cal-x', true);
+    const p2 = filter._handleToggle('cal-y', true);
+    await Promise.all([p1, p2]);
+
+    // First op rolled back (cal-x dropped); second op still applied (cal-y kept).
+    expect(filter.selectedIds).toEqual(['cal-y']);
+  });
+
+  test('concurrent group toggles serialize without losing members', async () => {
+    const { filter } = buildFilter({ selectedIds: [] });
+
+    const p1 = filter._handleGroupToggle(GROUP_A, [], true);
+    const p2 = filter._handleGroupToggle(GROUP_B, [], true);
+    await Promise.all([p1, p2]);
+
+    expect([...filter.selectedIds].sort()).toEqual(['cal-x', 'cal-y', 'cal-z']);
+    const lastSaved = saveSelectedCalendars.mock.calls.at(-1)[0];
+    expect([...lastSaved].sort()).toEqual(['cal-x', 'cal-y', 'cal-z']);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a race condition in the timeline calendar filter where concurrent toggle operations could interleave their save/rollback steps, causing out-of-order storage writes or a rollback clobbering a later change. Introduces an operation queue (`_opQueue`) to serialize all selection-mutating tasks.

## Key Changes

- **Added operation queue infrastructure**: New `_opQueue` Promise chain and `_enqueue()` method to serialize selection mutations. Tasks are chained so concurrent toggles cannot interleave their compute/save/rollback steps; each task observes the fully-settled state of the one before it.

- **Wrapped toggle handlers in queue**: Both `_handleToggle()` and `_handleGroupToggle()` now enqueue their operations, ensuring rapid or bulk toggles complete atomically without racing.

- **Wrapped calendar fetch in queue**: `_fetchCalendars()` now enqueues its state-loading logic so concurrent reloads don't race with in-flight toggle saves, preventing half-written state observations.

- **Added destroy guard**: New `_destroyed` flag prevents queued tasks from persisting post-destroy state (empty selection, null renderer) that would crash the component.

- **Improved error handling**: Refactored error UI rendering into a `showError()` helper and fixed error path to only render if dropdown is still open.

- **Snapshot state inside queued tasks**: `previousIds` and other snapshots are now captured inside the queued task, ensuring they reflect any prior toggle's effects rather than racing with concurrent operations.

## Implementation Details

- The `_enqueue()` method chains tasks through `_opQueue` and keeps the chain alive even if a task throws, ensuring subsequent operations still execute.
- Tasks guarded by `_destroyed` flag skip execution entirely once the component is destroyed, preventing post-destroy state from persisting.
- Concurrent toggles now serialize: `toggle(cal-x, true)` followed by `toggle(cal-y, true)` will save `[cal-x, cal-y]` in the final persisted state, not race to an inconsistent result.
- Added comprehensive test coverage for concurrent toggle serialization, failed save recovery, and destroy-time safety.

https://claude.ai/code/session_01NHw85Tq9qfEKMipfF2wb9C