### PR TITLE
Fix: skip reminders for out-of-office and other non-meeting Google events

### DIFF
--- a/src/lib/alarm-manager.js
+++ b/src/lib/alarm-manager.js
@@ -10,6 +10,11 @@ export class AlarmManager {
     static GOOGLE_ALARM_PREFIX = 'google_event_reminder_';
     static REMINDER_MINUTES = 5;
 
+    // Google Calendar eventTypes that are status markers rather than meetings.
+    // These should never trigger a reminder notification (e.g. an out-of-office
+    // block is not something the user needs to be reminded to "attend").
+    static NON_MEETING_EVENT_TYPES = ['outOfOffice', 'focusTime', 'workingLocation'];
+
     /**
      * Set a reminder for an event
      * @param {Object} event The event object with id, title, startTime
@@ -276,6 +281,13 @@ export class AlarmManager {
     static async setGoogleEventReminder(event, dateStr, reminderMinutes = null) {
         if (!event.start || !event.start.dateTime) {
             return; // Skip all-day events
+        }
+
+        // Skip non-meeting event types (out-of-office, focus time, working
+        // location). These are status markers, not meetings, so a reminder
+        // notification makes no sense and confuses the user.
+        if (this.NON_MEETING_EVENT_TYPES.includes(event.eventType)) {
+            return;
         }
 
         try {

--- a/tests/lib/alarm-manager.test.js
+++ b/tests/lib/alarm-manager.test.js
@@ -90,6 +90,19 @@ describe('AlarmManager', () => {
             await AlarmManager.setGoogleEventReminder({ id: 'g1' }, '2030-03-15', 5);
             expect(chrome.alarms.create).not.toHaveBeenCalled();
         });
+
+        test.each(['outOfOffice', 'focusTime', 'workingLocation'])(
+            'non-meeting eventType "%s" is skipped even when timed',
+            async (eventType) => {
+                const tomorrow = new Date();
+                tomorrow.setDate(tomorrow.getDate() + 1);
+                await AlarmManager.setGoogleEventReminder(
+                    { id: 'g1', summary: 'OOO', eventType, start: { dateTime: tomorrow.toISOString() } },
+                    '2030-03-15', 5
+                );
+                expect(chrome.alarms.create).not.toHaveBeenCalled();
+            }
+        );
     });
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
Out-of-office, focus time, and working location events are status
markers rather than meetings, so scheduling a reminder notification for
them is confusing. setGoogleEventReminder now skips these eventTypes,
matching how the timeline already treats them as non-meeting events.

https://claude.ai/code/session_01KDFGipjpPzd2QSPGpYbFZZ