### PR TITLE
Add release announcement workflow with approval flow

### DIFF
--- a/.github/release-announcement.md
+++ b/.github/release-announcement.md
@@ -1,0 +1,89 @@
+# リリース告知ワークフロー 運用ガイド
+
+`.github/workflows/release-announce.yml` の使い方・セットアップ手順。
+GitHub リリース公開をトリガーに、Claude が告知文を生成し、**手動承認後**に
+X / LinkedIn / Reddit へ自動投稿する。
+
+## 全体の流れ
+
+```
+タグ push
+  └─ ci.yml がビルド → GitHub リリースを作成（release: published 発火）
+       └─ release-announce.yml
+            ├─ generate : Claude が媒体別の告知文を生成し Step Summary に下書き表示
+            └─ post     : 「announce」環境の承認ゲートで待機
+                            └─ Approve 後に X / LinkedIn / Reddit へ投稿
+```
+
+承認ゲートが「**Chrome ウェブストア公開後に告知する**」タイミング制御を兼ねる。
+ストアの掲載がライブになったのを確認してから Approve する。
+
+## 一度だけ行うセットアップ
+
+### 1. `announce` 環境を作成
+Settings → Environments → New environment → 名前 `announce`。
+**Required reviewers** に自分を追加（これで投稿前に承認待ちになる）。
+
+### 2. シークレットを登録
+
+**リポジトリ**（Settings → Secrets and variables → Actions）:
+
+| シークレット | 用途 |
+|---|---|
+| `ANTHROPIC_API_KEY` | generate ジョブの告知文生成（environment 不可・リポジトリ必須） |
+
+**`announce` 環境**（使う媒体のぶんだけ。未設定の媒体は自動でスキップされる）:
+
+| 媒体 | シークレット |
+|---|---|
+| X | `X_CONSUMER_KEY`, `X_CONSUMER_SECRET`, `X_ACCESS_TOKEN`, `X_ACCESS_SECRET` |
+| LinkedIn | `LINKEDIN_ACCESS_TOKEN`, `LINKEDIN_PERSON_ID` |
+| Reddit | `REDDIT_CLIENT_ID`, `REDDIT_CLIENT_SECRET`, `REDDIT_USERNAME`, `REDDIT_PASSWORD` |
+
+### 3. 各プラットフォームの開発者設定
+
+- **X**: [developer.x.com](https://developer.x.com) でアプリ作成 →
+  「User authentication settings」を **Read and write** に →
+  Consumer Keys と Access Token/Secret を発行（無料枠で投稿可・月次/24h上限あり）。
+- **LinkedIn**: [developer.linkedin.com](https://developer.linkedin.com) でアプリ作成 →
+  製品「**Share on LinkedIn**」を追加して `w_member_social` を取得 → 3-legged OAuth で
+  アクセストークン発行（**約60日で失効**）。`LINKEDIN_PERSON_ID` は `GET /v2/userinfo` の `sub`。
+- **Reddit**: [reddit.com/prefs/apps](https://www.reddit.com/prefs/apps) で **script** タイプの
+  アプリを作成 → client_id / secret を取得（API 利用申請の承認が要る場合あり）。
+
+## リリースのたびの操作
+
+1. タグ（`*.*.*`）を push → CI が GitHub リリースを作成
+2. 告知ワークフローが起動。**Actions の generate の Step Summary** で3媒体の下書きを確認
+3. Chrome ウェブストアへ手動アップロード＆公開。掲載がライブになったのを確認
+4. `post` ジョブを **Approve**（または Reject）→ 投稿後、Summary に ✅/⏭️/❌ が出る
+
+> 各媒体の結果: **✅ posted** / **⏭️ skipped（secret 未設定）** / **❌ failed（設定済みだが失敗）**。
+> ❌ が1つでもあると run は赤くなる（未設定スキップでは赤くならない）。
+
+## ⏰ 推奨投稿時間（JST・目安）
+
+告知文は日本語なので主対象は日本のユーザー。承認＝投稿のため、下記の時間帯に Approve する。
+（出典の数値は「対象オーディエンスのローカル時間」基準。詳細は下部リンク参照）
+
+| 媒体 | 推奨曜日 | 推奨時間（JST） | 補足 |
+|---|---|---|---|
+| **X** | 火〜木 | 昼 12時前後 / 夜 20〜23時 | 土曜は最も反応が低い |
+| **LinkedIn** | 火〜木 | 午後 15〜18時 | 近年は午後〜夕方が朝より強い。月曜は弱い |
+| **Reddit** | 平日朝〜週末 | JST 21〜23時頃（US東部の朝） | 米国/英語圏中心。日本語の自プロフィール投稿は反応薄め |
+
+横断的な無難ライン: **平日（火〜木）の昼または夕方**。
+
+## 注意点（コードで吸収できない仕様上の制約）
+
+- **LinkedIn トークンは約60日で失効** → 失効後は LinkedIn だけ ❌ になる（他は投稿継続）。
+  定期的に `LINKEDIN_ACCESS_TOKEN` を再発行・更新する。
+- **`LinkedIn-Version`（YYYYMM）は約1年で sunset** → ワークフロー内の値（現在 `202605`）を
+  ときどき新しい月次へ更新する。
+- **Reddit**: アカウントが 2FA 有効だと password は `password:TOTP` 形式が必要。
+  新規アカウントはスパムフィルタに留まる場合あり。
+- **再実行＝二重投稿**: `post` を再実行すると同じ内容を再投稿する。1リリース＝1回 Approve で運用。
+
+## 参考リンク（投稿時間の出典）
+- Sprout Social「Best Times to Post on Social Media 2026」
+- Buffer「Best Time to Post on LinkedIn / Twitter-X in 2026」

--- a/.github/workflows/release-announce.yml
+++ b/.github/workflows/release-announce.yml
@@ -127,6 +127,12 @@ jobs:
           X_ACCESS_TOKEN:    ${{ secrets.X_ACCESS_TOKEN }}
           X_ACCESS_SECRET:   ${{ secrets.X_ACCESS_SECRET }}
         run: |
+          set -euo pipefail
+          if [ -z "${X_CONSUMER_KEY:-}" ]; then
+            echo "result=skipped" >> "$GITHUB_OUTPUT"
+            echo "X: secret 未設定のためスキップ"
+            exit 0
+          fi
           node <<'EOF'
           const crypto = require('crypto');
           const https = require('https');
@@ -177,6 +183,7 @@ jobs:
           req.write(body);
           req.end();
           EOF
+          echo "result=posted" >> "$GITHUB_OUTPUT"
 
       # --- LinkedIn : 個人プロフィールへ Posts API で投稿 ---
       - name: Post to LinkedIn
@@ -185,11 +192,25 @@ jobs:
         env:
           TOKEN:            ${{ secrets.LINKEDIN_ACCESS_TOKEN }}
           PERSON_ID:        ${{ secrets.LINKEDIN_PERSON_ID }}
-          LINKEDIN_VERSION: "202506"   # YYYYMM。sunset されたら新しい月次へ更新
+          LINKEDIN_VERSION: "202605"   # YYYYMM。各版はリリースから約1年で sunset → 定期更新
           RELEASE_NAME:     ${{ github.event.release.name }}
         run: |
           set -euo pipefail
-          TEXT=$(cat linkedin.txt)
+          if [ -z "${TOKEN:-}" ]; then
+            echo "result=skipped" >> "$GITHUB_OUTPUT"
+            echo "LinkedIn: secret 未設定のためスキップ"
+            exit 0
+          fi
+          # commentary は LinkedIn の "Little Text" 形式。予約文字をバックスラッシュで
+          # エスケープしないと 422 になり、特に括弧があると以降が黙って欠落する。
+          # （article.title / source は Little Text ではないのでエスケープ不要）
+          python3 - <<'PY' > linkedin_escaped.txt
+          import sys
+          reserved = set('\\|{}@[]()<>#*_~')
+          s = open('linkedin.txt', encoding='utf-8').read()
+          sys.stdout.write(''.join('\\' + c if c in reserved else c for c in s))
+          PY
+          TEXT=$(cat linkedin_escaped.txt)
           LINK=$(cat link.txt)
           TITLE="${RELEASE_NAME:-SideTimeTable}"
 
@@ -219,6 +240,7 @@ jobs:
             200|201) echo "LinkedIn post OK" ;;
             *) echo "LinkedIn post failed"; exit 1 ;;
           esac
+          echo "result=posted" >> "$GITHUB_OUTPUT"
 
       # --- Reddit : 自分のプロフィール(u_/)へリンク投稿 ---
       - name: Post to Reddit
@@ -231,6 +253,11 @@ jobs:
           RPASS:   ${{ secrets.REDDIT_PASSWORD }}
         run: |
           set -euo pipefail
+          if [ -z "${CID:-}" ]; then
+            echo "result=skipped" >> "$GITHUB_OUTPUT"
+            echo "Reddit: secret 未設定のためスキップ"
+            exit 0
+          fi
           UA="SideTimeTable-release-bot/1.0 by $RUSER"
 
           # password grant で短命トークンを取得
@@ -257,22 +284,43 @@ jobs:
           # エラーが無く、投稿URLが返ったことを確認
           echo "$RESP" | jq -e '(.json.errors == []) and (.json.data.url != null)' >/dev/null \
             || { echo "Reddit submit failed"; exit 1; }
+          echo "result=posted" >> "$GITHUB_OUTPUT"
 
-      # --- 結果集計：各媒体の成否を Summary に出し、1つでも失敗なら run を赤くする ---
+      # --- 結果集計 ---
+      # 各媒体について outcome(success/failure) と result(posted/skipped) を組み合わせ、
+      #   投稿成功=✅ / 秘密未設定スキップ=⏭️ / 失敗=❌ を表示。
+      # ❌（=秘密が設定済みなのに投稿失敗）が1つでもあれば run を赤くする。
+      # 未設定スキップでは赤くしない（媒体を段階的に追加できるようにするため）。
       - name: Summarize results
         if: always()
+        env:
+          X_OUTCOME: ${{ steps.x.outcome }}
+          X_RESULT:  ${{ steps.x.outputs.result }}
+          L_OUTCOME: ${{ steps.linkedin.outcome }}
+          L_RESULT:  ${{ steps.linkedin.outputs.result }}
+          R_OUTCOME: ${{ steps.reddit.outcome }}
+          R_RESULT:  ${{ steps.reddit.outputs.result }}
         run: |
-          X='${{ steps.x.outcome }}'
-          L='${{ steps.linkedin.outcome }}'
-          R='${{ steps.reddit.outcome }}'
-          icon() { [ "$1" = "success" ] && echo "✅" || echo "❌"; }
+          set -uo pipefail
+          FAILED=0
+          line() {
+            # $1=媒体名 $2=outcome $3=result
+            if [ "$2" = "success" ] && [ "$3" = "skipped" ]; then
+              echo "- $1: ⏭️ skipped（secret 未設定）"
+            elif [ "$2" = "success" ]; then
+              echo "- $1: ✅ posted"
+            else
+              echo "- $1: ❌ failed"
+              FAILED=1
+            fi
+          }
           {
             echo "## 投稿結果"
-            echo "- X: $(icon "$X") ($X)"
-            echo "- LinkedIn: $(icon "$L") ($L)"
-            echo "- Reddit: $(icon "$R") ($R)"
+            line "X"        "$X_OUTCOME" "$X_RESULT"
+            line "LinkedIn" "$L_OUTCOME" "$L_RESULT"
+            line "Reddit"   "$R_OUTCOME" "$R_RESULT"
           } >> "$GITHUB_STEP_SUMMARY"
-          if [ "$X" != "success" ] || [ "$L" != "success" ] || [ "$R" != "success" ]; then
+          if [ "$FAILED" -ne 0 ]; then
             echo "1つ以上の媒体で投稿に失敗しました"
             exit 1
           fi

--- a/.github/workflows/release-announce.yml
+++ b/.github/workflows/release-announce.yml
@@ -1,4 +1,4 @@
-name: Release Announcement
+name: Release Announcement (X / LinkedIn / Reddit)
 
 on:
   release:
@@ -8,11 +8,11 @@ permissions:
   contents: read
 
 jobs:
-  # ① Claude で告知文を生成し、下書きを保存・表示
+  # ① Claude で媒体別の告知文(JSON)を生成し、下書きを保存・表示
   generate:
     runs-on: ubuntu-latest
     steps:
-      - name: Generate announcement text
+      - name: Generate announcement texts
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           # ↓ リリース情報は env 経由で渡す（安全のため。run内に直接書かない）
@@ -20,8 +20,15 @@ jobs:
           RELEASE_URL:   ${{ github.event.release.html_url }}
           RELEASE_NOTES: ${{ github.event.release.body }}
         run: |
-          # Claude へのお願い文（プロンプト）を組み立て
-          PROMPT="あなたは開発者の広報担当です。次のリリース情報から、X(旧Twitter)向けの告知文を日本語で140字以内で作ってください。絵文字は1〜2個まで。URLやリンクは本文に含めないでください。本文だけを出力し、前置きや説明は書かないでください。
+          set -euo pipefail
+
+          # Claude へのお願い文（プロンプト）。媒体別に最適化した JSON を1回で生成させる
+          PROMPT="あなたは開発者の広報担当です。次のリリース情報から、X(旧Twitter)・LinkedIn・Reddit 向けの告知文を日本語で作成してください。
+
+          出力は次のキーを持つ生のJSONのみ。コードフェンスや前置き・説明は一切書かないでください。
+          - \"x\": X向け本文。全角140字以内（XはCJKを2カウントするため）。URLやリンクは含めない。絵文字は1〜2個まで。
+          - \"linkedin\": LinkedIn向け本文。プロフェッショナルな数文。URLは含めなくてよい（別途リンクを記事として添付します）。
+          - \"reddit_title\": Reddit投稿のタイトル。300字以内。URLは含めない。
 
           製品/リリース名: ${RELEASE_NAME}
           リリースノート:
@@ -34,25 +41,49 @@ jobs:
             messages: [{ role: "user", content: $p }]
           }')
 
-          # API 呼び出し
           RES=$(curl -s https://api.anthropic.com/v1/messages \
             -H "x-api-key: $ANTHROPIC_API_KEY" \
             -H "anthropic-version: 2023-06-01" \
             -H "Content-Type: application/json" \
             -d "$BODY")
 
-          # 生成された文面を取り出してファイルに保存
-          echo "$RES" | jq -r '.content[0].text' > message.txt
+          # 生成テキストを取り出す
+          echo "$RES" | jq -r '.content[0].text' > raw.txt
 
-          # リンクは別行に保存（X はURL課金が高いので、投稿時は本文と分ける）
+          # コードフェンスや前置きが混じっても頑健に JSON を抽出・検証して各ファイルへ保存
+          python3 - <<'PY'
+          import json, re, sys
+          raw = open('raw.txt', encoding='utf-8').read()
+          m = re.search(r'\{.*\}', raw, re.S)
+          if not m:
+              sys.exit("Claude応答からJSONを抽出できませんでした")
+          obj = json.loads(m.group(0))
+          for key, fn in (('x', 'x.txt'), ('linkedin', 'linkedin.txt'), ('reddit_title', 'reddit_title.txt')):
+              val = (obj.get(key) or '').strip()
+              if not val:
+                  sys.exit(f"空のフィールド: {key}")
+              with open(fn, 'w', encoding='utf-8') as f:
+                  f.write(val)
+          PY
+
+          # リンクは別ファイルに保存（X は本文に含めない方針）
           echo "$RELEASE_URL" > link.txt
 
           # 承認画面の前に内容を確認できるよう、サマリーに表示
           {
             echo "## 📝 生成された告知文（承認前に確認してください）"
             echo ""
+            echo "### X"
             echo '```'
-            cat message.txt
+            cat x.txt
+            echo '```'
+            echo "### LinkedIn"
+            echo '```'
+            cat linkedin.txt
+            echo '```'
+            echo "### Reddit (title)"
+            echo '```'
+            cat reddit_title.txt
             echo '```'
             echo ""
             echo "リンク: $RELEASE_URL"
@@ -65,26 +96,183 @@ jobs:
         with:
           name: announcement
           path: |
-            message.txt
+            x.txt
+            linkedin.txt
+            reddit_title.txt
             link.txt
 
-  # ② 承認後にだけ動く投稿ジョブ
+  # ② 承認後にだけ動く投稿ジョブ。各媒体は独立ステップ（1つ失敗しても他は続行）
   post:
     needs: generate
     runs-on: ubuntu-latest
     environment: announce   # ← この行で「承認待ち」になる（事前準備Aの環境名と一致）
     steps:
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
       - name: Download draft
         uses: actions/download-artifact@v4
         with:
           name: announcement
 
-      - name: Post
+      # --- X (Twitter) : OAuth 1.0a user context ---
+      - name: Post to X
+        id: x
+        continue-on-error: true
+        env:
+          X_CONSUMER_KEY:    ${{ secrets.X_CONSUMER_KEY }}
+          X_CONSUMER_SECRET: ${{ secrets.X_CONSUMER_SECRET }}
+          X_ACCESS_TOKEN:    ${{ secrets.X_ACCESS_TOKEN }}
+          X_ACCESS_SECRET:   ${{ secrets.X_ACCESS_SECRET }}
         run: |
-          MESSAGE=$(cat message.txt)
+          node <<'EOF'
+          const crypto = require('crypto');
+          const https = require('https');
+          const fs = require('fs');
+
+          const ck = process.env.X_CONSUMER_KEY;
+          const cs = process.env.X_CONSUMER_SECRET;
+          const tok = process.env.X_ACCESS_TOKEN;
+          const toks = process.env.X_ACCESS_SECRET;
+          const text = fs.readFileSync('x.txt', 'utf8').trim();
+
+          // RFC3986 percent-encoding
+          const pe = s => encodeURIComponent(s).replace(/[!*'()]/g, c => '%' + c.charCodeAt(0).toString(16).toUpperCase());
+
+          const url = 'https://api.twitter.com/2/tweets';
+          const oauth = {
+            oauth_consumer_key: ck,
+            oauth_nonce: crypto.randomBytes(16).toString('hex'),
+            oauth_signature_method: 'HMAC-SHA1',
+            oauth_timestamp: Math.floor(Date.now() / 1000).toString(),
+            oauth_token: tok,
+            oauth_version: '1.0',
+          };
+          // JSON body は署名対象外。oauth_* のみで署名ベース文字列を作る
+          const paramStr = Object.keys(oauth).sort().map(k => pe(k) + '=' + pe(oauth[k])).join('&');
+          const base = 'POST&' + pe(url) + '&' + pe(paramStr);
+          const signingKey = pe(cs) + '&' + pe(toks);
+          oauth.oauth_signature = crypto.createHmac('sha1', signingKey).update(base).digest('base64');
+          const authHeader = 'OAuth ' + Object.keys(oauth).sort().map(k => pe(k) + '="' + pe(oauth[k]) + '"').join(', ');
+
+          const body = JSON.stringify({ text });
+          const req = https.request(url, {
+            method: 'POST',
+            headers: {
+              'Authorization': authHeader,
+              'Content-Type': 'application/json',
+              'Content-Length': Buffer.byteLength(body),
+            },
+          }, res => {
+            let data = '';
+            res.on('data', d => data += d);
+            res.on('end', () => {
+              console.log('X status:', res.statusCode, data);
+              process.exit(res.statusCode >= 200 && res.statusCode < 300 ? 0 : 1);
+            });
+          });
+          req.on('error', e => { console.error(e); process.exit(1); });
+          req.write(body);
+          req.end();
+          EOF
+
+      # --- LinkedIn : 個人プロフィールへ Posts API で投稿 ---
+      - name: Post to LinkedIn
+        id: linkedin
+        continue-on-error: true
+        env:
+          TOKEN:            ${{ secrets.LINKEDIN_ACCESS_TOKEN }}
+          PERSON_ID:        ${{ secrets.LINKEDIN_PERSON_ID }}
+          LINKEDIN_VERSION: "202506"   # YYYYMM。sunset されたら新しい月次へ更新
+          RELEASE_NAME:     ${{ github.event.release.name }}
+        run: |
+          set -euo pipefail
+          TEXT=$(cat linkedin.txt)
           LINK=$(cat link.txt)
-          echo "▼ 投稿する文面:"
-          echo "$MESSAGE"
-          echo "▼ リンク: $LINK"
-          # ↓↓↓ まずはここまでで「生成→承認→確認」が動きます。
-          # 実際のSNS投稿は、release告知how-to末尾のセクションを参照して差し込みます。
+          TITLE="${RELEASE_NAME:-SideTimeTable}"
+
+          BODY=$(jq -n \
+            --arg author "urn:li:person:$PERSON_ID" \
+            --arg text "$TEXT" \
+            --arg link "$LINK" \
+            --arg title "$TITLE" '{
+              author: $author,
+              commentary: $text,
+              visibility: "PUBLIC",
+              distribution: { feedDistribution: "MAIN_FEED", targetEntities: [], thirdPartyDistributionChannels: [] },
+              content: { article: { source: $link, title: $title } },
+              lifecycleState: "PUBLISHED",
+              isReshareDisabledByAuthor: false
+            }')
+
+          HTTP=$(curl -s -o resp.txt -w '%{http_code}' -X POST https://api.linkedin.com/rest/posts \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "LinkedIn-Version: $LINKEDIN_VERSION" \
+            -H "X-Restli-Protocol-Version: 2.0.0" \
+            -H "Content-Type: application/json" \
+            -d "$BODY")
+          echo "LinkedIn HTTP $HTTP"
+          cat resp.txt || true
+          case "$HTTP" in
+            200|201) echo "LinkedIn post OK" ;;
+            *) echo "LinkedIn post failed"; exit 1 ;;
+          esac
+
+      # --- Reddit : 自分のプロフィール(u_/)へリンク投稿 ---
+      - name: Post to Reddit
+        id: reddit
+        continue-on-error: true
+        env:
+          CID:     ${{ secrets.REDDIT_CLIENT_ID }}
+          CSECRET: ${{ secrets.REDDIT_CLIENT_SECRET }}
+          RUSER:   ${{ secrets.REDDIT_USERNAME }}
+          RPASS:   ${{ secrets.REDDIT_PASSWORD }}
+        run: |
+          set -euo pipefail
+          UA="SideTimeTable-release-bot/1.0 by $RUSER"
+
+          # password grant で短命トークンを取得
+          TOKEN=$(curl -s -X POST https://www.reddit.com/api/v1/access_token \
+            -A "$UA" \
+            -u "$CID:$CSECRET" \
+            --data-urlencode "grant_type=password" \
+            --data-urlencode "username=$RUSER" \
+            --data-urlencode "password=$RPASS" | jq -r '.access_token // empty')
+          [ -n "$TOKEN" ] || { echo "Reddit token exchange failed"; exit 1; }
+
+          TITLE=$(cat reddit_title.txt)
+          LINK=$(cat link.txt)
+
+          RESP=$(curl -s -X POST https://oauth.reddit.com/api/submit \
+            -A "$UA" \
+            -H "Authorization: bearer $TOKEN" \
+            --data-urlencode "api_type=json" \
+            --data-urlencode "sr=u_$RUSER" \
+            --data-urlencode "kind=link" \
+            --data-urlencode "title=$TITLE" \
+            --data-urlencode "url=$LINK")
+          echo "$RESP"
+          # エラーが無く、投稿URLが返ったことを確認
+          echo "$RESP" | jq -e '(.json.errors == []) and (.json.data.url != null)' >/dev/null \
+            || { echo "Reddit submit failed"; exit 1; }
+
+      # --- 結果集計：各媒体の成否を Summary に出し、1つでも失敗なら run を赤くする ---
+      - name: Summarize results
+        if: always()
+        run: |
+          X='${{ steps.x.outcome }}'
+          L='${{ steps.linkedin.outcome }}'
+          R='${{ steps.reddit.outcome }}'
+          icon() { [ "$1" = "success" ] && echo "✅" || echo "❌"; }
+          {
+            echo "## 投稿結果"
+            echo "- X: $(icon "$X") ($X)"
+            echo "- LinkedIn: $(icon "$L") ($L)"
+            echo "- Reddit: $(icon "$R") ($R)"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$X" != "success" ] || [ "$L" != "success" ] || [ "$R" != "success" ]; then
+            echo "1つ以上の媒体で投稿に失敗しました"
+            exit 1
+          fi

--- a/.github/workflows/release-announce.yml
+++ b/.github/workflows/release-announce.yml
@@ -88,6 +88,12 @@ jobs:
             echo ""
             echo "リンク: $RELEASE_URL"
             echo ""
+            echo "### ⏰ 推奨投稿時間（JST・目安）"
+            echo "承認＝投稿なので、ストア公開を確認のうえ下記の時間帯に Approve するのが目安です。"
+            echo "- **X**: 平日 火〜木。昼 12時前後 / 夜 20〜23時"
+            echo "- **LinkedIn**: 平日 火〜木の午後（15〜18時）。週末は避ける"
+            echo "- **Reddit**: 米国中心のため US東部の朝＝JST 21〜23時頃 or 週末（日本語投稿は反応薄め）"
+            echo ""
             echo "内容がOKなら post ジョブを **Approve**、ダメなら **Reject** してください。"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/release-announce.yml
+++ b/.github/workflows/release-announce.yml
@@ -1,0 +1,90 @@
+name: Release Announcement
+
+on:
+  release:
+    types: [published]   # リリースを「公開」したときに発火
+
+permissions:
+  contents: read
+
+jobs:
+  # ① Claude で告知文を生成し、下書きを保存・表示
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate announcement text
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          # ↓ リリース情報は env 経由で渡す（安全のため。run内に直接書かない）
+          RELEASE_NAME:  ${{ github.event.release.name }}
+          RELEASE_URL:   ${{ github.event.release.html_url }}
+          RELEASE_NOTES: ${{ github.event.release.body }}
+        run: |
+          # Claude へのお願い文（プロンプト）を組み立て
+          PROMPT="あなたは開発者の広報担当です。次のリリース情報から、X(旧Twitter)向けの告知文を日本語で140字以内で作ってください。絵文字は1〜2個まで。URLやリンクは本文に含めないでください。本文だけを出力し、前置きや説明は書かないでください。
+
+          製品/リリース名: ${RELEASE_NAME}
+          リリースノート:
+          ${RELEASE_NOTES}"
+
+          # Anthropic Messages API へのリクエストを jq で安全に組み立て
+          BODY=$(jq -n --arg p "$PROMPT" '{
+            model: "claude-sonnet-4-6",
+            max_tokens: 1024,
+            messages: [{ role: "user", content: $p }]
+          }')
+
+          # API 呼び出し
+          RES=$(curl -s https://api.anthropic.com/v1/messages \
+            -H "x-api-key: $ANTHROPIC_API_KEY" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "Content-Type: application/json" \
+            -d "$BODY")
+
+          # 生成された文面を取り出してファイルに保存
+          echo "$RES" | jq -r '.content[0].text' > message.txt
+
+          # リンクは別行に保存（X はURL課金が高いので、投稿時は本文と分ける）
+          echo "$RELEASE_URL" > link.txt
+
+          # 承認画面の前に内容を確認できるよう、サマリーに表示
+          {
+            echo "## 📝 生成された告知文（承認前に確認してください）"
+            echo ""
+            echo '```'
+            cat message.txt
+            echo '```'
+            echo ""
+            echo "リンク: $RELEASE_URL"
+            echo ""
+            echo "内容がOKなら post ジョブを **Approve**、ダメなら **Reject** してください。"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload draft
+        uses: actions/upload-artifact@v4
+        with:
+          name: announcement
+          path: |
+            message.txt
+            link.txt
+
+  # ② 承認後にだけ動く投稿ジョブ
+  post:
+    needs: generate
+    runs-on: ubuntu-latest
+    environment: announce   # ← この行で「承認待ち」になる（事前準備Aの環境名と一致）
+    steps:
+      - name: Download draft
+        uses: actions/download-artifact@v4
+        with:
+          name: announcement
+
+      - name: Post
+        run: |
+          MESSAGE=$(cat message.txt)
+          LINK=$(cat link.txt)
+          echo "▼ 投稿する文面:"
+          echo "$MESSAGE"
+          echo "▼ リンク: $LINK"
+          # ↓↓↓ まずはここまでで「生成→承認→確認」が動きます。
+          # 実際のSNS投稿は、release告知how-to末尾のセクションを参照して差し込みます。


### PR DESCRIPTION
Generate announcement text via Claude on release publish, then gate
SNS posting behind a manual approval using the 'announce' environment.