### PR TITLE
Add GitHub Sponsors section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ Notes:
 - `enableReminderDebug` remains for backward compatibility but may be deprecated later.
 - No extra Chrome permissions are required for these toggles.
 
+### Sponsor
+If SideTimeTable is useful to you, you can support its development through [GitHub Sponsors](https://github.com/sponsors/badfalcon). Sponsorships help cover maintenance and new features — the extension stays free either way.
+
 ### License
 This plugin is released under the [Apache License 2.0]. See the `LICENSE` file for details.
 
@@ -192,6 +195,9 @@ chrome.storage.local.set({ enableDeveloperFeatures: false, enableReminderDebug: 
   2. `src/` 内のソースファイルを編集
   3. Chromeで拡張機能をリロードして変更を確認
   4. `npm run package` で配布用zipを作成
+
+### スポンサー
+SideTimeTable が役に立ったら、[GitHub Sponsors](https://github.com/sponsors/badfalcon) から開発を支援できます。いただいた支援はメンテナンスや新機能の開発に充てられます（拡張機能は今後も無料でご利用いただけます）。
 
 ### ライセンス
 このプラグインは[Apache License 2.0]の下で公開されています。詳細は`LICENSE`ファイルを参照してください。


### PR DESCRIPTION
## Summary
Added a "Sponsor" section to the README in both English and Japanese to encourage users to support the project's development through GitHub Sponsors.

## Changes
- Added English "Sponsor" section after the configuration notes and before the License section
- Added Japanese "スポンサー" section in the corresponding location in the Japanese documentation
- Both sections include a link to the GitHub Sponsors page and clarify that the extension remains free regardless of sponsorship

## Details
The new sections are positioned consistently in both language versions of the README, maintaining the existing document structure and formatting conventions. The messaging emphasizes that sponsorships support maintenance and new features while the extension stays free.

https://claude.ai/code/session_01Pr3XXizuW6utWXuMch7yE9