### PR TITLE
docs: README タイトル直下に GitHub Sponsors バッジを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SideTimeTable
 
+[![Sponsor](https://img.shields.io/github/sponsors/badfalcon?logo=githubsponsors&logoColor=white&label=Sponsor&color=ea4aaa)](https://github.com/sponsors/badfalcon)
+
 ## English
 
 ### Overview


### PR DESCRIPTION
## 概要

PR #85 でスポンサー節を追加した続きとして、README のタイトル `# SideTimeTable` 直下に GitHub Sponsors バッジを追加します。

## 変更内容

- `README.md`: タイトル直下にバッジ行を1行追加（+2行のみ）

```markdown
[[Sponsor](``https://img.shields.io/github/sponsors/badfalcon?logo=githubsponsors&logoColor=white&label=Sponsor&color=ea4aaa)](https://github.com/sponsors/badfalcon``)
```

- `## English` / `## 日本語` より上に配置しているため、どちらの読者にも表示されます
- リンク先は `.github/FUNDING.yml` の `github: badfalcon` と同じ https://github.com/sponsors/badfalcon
- PR #85 で追加した `### Sponsor` / `### スポンサー` 節はそのまま残しています（説明文はバッジだけでは伝わらないため）

## 補足

Markdown のみの変更で `src/` のコードは変更していないため、テスト・lint は実行していません。

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pr3XXizuW6utWXuMch7yE9)_