### PR TITLE
docs: README に CI / Chrome Web Store / ライセンスのバッジを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # SideTimeTable
 
+[![CI](https://github.com/badfalcon/SideTimeTable/actions/workflows/ci.yml/badge.svg)](https://github.com/badfalcon/SideTimeTable/actions/workflows/ci.yml)
+[![Chrome Web Store](https://img.shields.io/chrome-web-store/v/pnknjjpncnciijkpdfgfiikmhlmamaid?logo=googlechrome&logoColor=white&label=Chrome%20Web%20Store)](https://chromewebstore.google.com/detail/sidetimetable/pnknjjpncnciijkpdfgfiikmhlmamaid)
+[![Users](https://img.shields.io/chrome-web-store/users/pnknjjpncnciijkpdfgfiikmhlmamaid?label=users)](https://chromewebstore.google.com/detail/sidetimetable/pnknjjpncnciijkpdfgfiikmhlmamaid)
+[![License](https://img.shields.io/github/license/badfalcon/SideTimeTable)](./LICENSE)
 [![Sponsor](https://img.shields.io/github/sponsors/badfalcon?logo=githubsponsors&logoColor=white&label=Sponsor&color=ea4aaa)](https://github.com/sponsors/badfalcon)
 
 ## English


### PR DESCRIPTION
## 概要

PR #86 でタイトル直下に置いた Sponsor バッジの行に、バッジを4つ追加します。並びは **CI → Chrome Web Store → Users → License → Sponsor**（ビルド状態 → 配布先 → ライセンス → 支援）。

## 変更内容

`README.md` に4行追加（+4行のみ）:

- **CI**: `.github/workflows/ci.yml` の実行状態。GitHub 純正のバッジで third-party 依存なし
- **Chrome Web Store**: 公開バージョン。拡張機能 ID `pnknjjpncnciijkpdfgfiikmhlmamaid`、リンクは新ドメイン `chromewebstore.google.com`
- **Users**: Chrome Web Store のユーザー数
- **License**: Apache-2.0。リンク先はリポジトリ内の `LICENSE`

## 補足

- GitHub Releases が未公開（タグのみ）のため `github/v/release` バッジは入れていません。バージョン表示は Chrome Web Store バッジが担います
- Chrome Web Store 系の2つは shields.io がストアから値を取得するため、Google 側の変更で一時的に表示が壊れることがあります。その場合は静的バッジへの差し替えが必要です
- Markdown のみの変更で `src/` のコードは変更していないため、テスト・lint は実行していません

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pr3XXizuW6utWXuMch7yE9)_