### PR TITLE
Add manual workflow dispatch to release announcement

### DIFF
--- a/.github/release-announcement.md
+++ b/.github/release-announcement.md
@@ -1,22 +1,39 @@
 # リリース告知ワークフロー 運用ガイド
 
 `.github/workflows/release-announce.yml` の使い方・セットアップ手順。
-GitHub リリース公開をトリガーに、Claude が告知文を生成し、**手動承認後**に
-X / LinkedIn / Reddit へ自動投稿する。
+Claude が告知文を生成し、**手動承認後**に X / LinkedIn / Reddit へ自動投稿する。
 
 ## 全体の流れ
 
 ```
 タグ push
-  └─ ci.yml がビルド → GitHub リリースを作成（release: published 発火）
-       └─ release-announce.yml
-            ├─ generate : Claude が媒体別の告知文を生成し Step Summary に下書き表示
-            └─ post     : 「announce」環境の承認ゲートで待機
-                            └─ Approve 後に X / LinkedIn / Reddit へ投稿
+  └─ ci.yml がビルド → GitHub リリースを作成
+       ↓（※ここは自動で繋がらない。下記「発火のしかた」参照）
+Actions → Release Announcement → Run workflow（tag 入力・空なら最新リリース）
+  └─ release-announce.yml
+       ├─ generate : 対象リリースを解決 → Claude が媒体別の告知文を生成し Step Summary に下書き表示
+       └─ post     : 「announce」環境の承認ゲートで待機
+                       └─ Approve 後に X / LinkedIn / Reddit へ投稿
 ```
 
 承認ゲートが「**Chrome ウェブストア公開後に告知する**」タイミング制御を兼ねる。
 ストアの掲載がライブになったのを確認してから Approve する。
+
+## 発火のしかた
+
+トリガーは2つ（`release-announce.yml` の `on:`）。
+
+| トリガー | 発火する条件 |
+|---|---|
+| `workflow_dispatch` | **通常はこちら。** Actions → Release Announcement → Run workflow。`tag` 入力で対象リリースを指定（空なら最新リリース） |
+| `release: published` | リリースを **人間のアカウント** が公開したとき（GitHub UI の Publish など） |
+
+> **ci.yml のタグ push では `release` イベントは発火しない。**
+> GitHub の仕様上、`GITHUB_TOKEN` が起こしたイベントは（`workflow_dispatch` /
+> `repository_dispatch` を除き）新しいワークフロー実行を作らない（再帰防止）。
+> ci.yml の `softprops/action-gh-release` はデフォルトの `GITHUB_TOKEN` でリリースを
+> 作るため、告知ワークフローは自動では起動しない。だから手動発火を用意している。
+> どのみち「ストア公開を確認してから告知」の運用なので、手動発火のほうが素直。
 
 ## 一度だけ行うセットアップ
 
@@ -54,9 +71,11 @@ Settings → Environments → New environment → 名前 `announce`。
 ## リリースのたびの操作
 
 1. タグ（`*.*.*`）を push → CI が GitHub リリースを作成
-2. 告知ワークフローが起動。**Actions の generate の Step Summary** で3媒体の下書きを確認
-3. Chrome ウェブストアへ手動アップロード＆公開。掲載がライブになったのを確認
-4. `post` ジョブを **Approve**（または Reject）→ 投稿後、Summary に ✅/⏭️/❌ が出る
+2. Chrome ウェブストアへ手動アップロード＆公開。掲載がライブになったのを確認
+3. Actions → **Release Announcement** → **Run workflow**
+   （`tag` は空でよい＝最新リリースが対象。古いリリースを告知し直すときだけタグを入れる）
+4. **generate の Step Summary** で3媒体の下書きを確認
+5. `post` ジョブを **Approve**（または Reject）→ 投稿後、Summary に ✅/⏭️/❌ が出る
 
 > 各媒体の結果: **✅ posted** / **⏭️ skipped（secret 未設定）** / **❌ failed（設定済みだが失敗）**。
 > ❌ が1つでもあると run は赤くなる（未設定スキップでは赤くならない）。
@@ -82,7 +101,8 @@ Settings → Environments → New environment → 名前 `announce`。
   ときどき新しい月次へ更新する。
 - **Reddit**: アカウントが 2FA 有効だと password は `password:TOTP` 形式が必要。
   新規アカウントはスパムフィルタに留まる場合あり。
-- **再実行＝二重投稿**: `post` を再実行すると同じ内容を再投稿する。1リリース＝1回 Approve で運用。
+- **再実行＝二重投稿**: `post` を再実行する／同じタグで再度 Run workflow すると同じ内容を
+  再投稿する。1リリース＝1回 Approve で運用。
 
 ## 参考リンク（投稿時間の出典）
 - Sprout Social「Best Times to Post on Social Media 2026」

--- a/.github/workflows/release-announce.yml
+++ b/.github/workflows/release-announce.yml
@@ -3,6 +3,15 @@ name: Release Announcement (X / LinkedIn / Reddit)
 on:
   release:
     types: [published]   # リリースを「公開」したときに発火
+  workflow_dispatch:     # 手動発火（ci.yml が GITHUB_TOKEN で作ったリリースでは release イベントが飛ばないため）
+    inputs:
+      tag:
+        description: '告知するリリースのタグ（空なら最新リリース）'
+        required: false
+        type: string
+
+run-name: >-
+  Announce ${{ inputs.tag || github.event.release.tag_name || 'latest release' }}
 
 permissions:
   contents: read
@@ -12,15 +21,52 @@ jobs:
   generate:
     runs-on: ubuntu-latest
     steps:
+      # release イベントならペイロードから、手動実行なら API から取得。
+      # どちらの経路でも同じ3ファイル（名前・URL・本文）に正規化して後続へ渡す。
+      - name: Resolve release info
+        env:
+          # ↓ リリース情報は env 経由で渡す（安全のため。run内に直接書かない）
+          GH_TOKEN:     ${{ github.token }}
+          GH_REPO:      ${{ github.repository }}
+          EVENT:        ${{ github.event_name }}
+          INPUT_TAG:    ${{ inputs.tag }}
+          EVENT_NAME:   ${{ github.event.release.name }}
+          EVENT_TAG:    ${{ github.event.release.tag_name }}
+          EVENT_URL:    ${{ github.event.release.html_url }}
+          EVENT_NOTES:  ${{ github.event.release.body }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT" = "release" ]; then
+            printf '%s\n' "${EVENT_NAME:-$EVENT_TAG}" > release_name.txt
+            printf '%s\n' "$EVENT_URL"                > link.txt
+            printf '%s\n' "${EVENT_NOTES:-}"          > release_notes.txt
+          else
+            # gh release view はタグ省略時に最新リリースを返す
+            if [ -n "${INPUT_TAG:-}" ]; then
+              gh release view "$INPUT_TAG" --json name,tagName,url,body > release.json
+            else
+              gh release view --json name,tagName,url,body > release.json
+            fi
+            jq -r 'if (.name // "") == "" then .tagName else .name end' release.json > release_name.txt
+            jq -r '.url'         release.json > link.txt
+            jq -r '.body // ""'  release.json > release_notes.txt
+          fi
+
+          # URL が取れていないと後続の投稿が壊れるのでここで落とす
+          [ -s link.txt ] && [ "$(cat link.txt)" != "null" ] || { echo "リリースURLを解決できませんでした"; exit 1; }
+          echo "対象リリース: $(cat release_name.txt) / $(cat link.txt)"
+
       - name: Generate announcement texts
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          # ↓ リリース情報は env 経由で渡す（安全のため。run内に直接書かない）
-          RELEASE_NAME:  ${{ github.event.release.name }}
-          RELEASE_URL:   ${{ github.event.release.html_url }}
-          RELEASE_NOTES: ${{ github.event.release.body }}
         run: |
           set -euo pipefail
+
+          # 前ステップが正規化したリリース情報を読み込む
+          RELEASE_NAME=$(cat release_name.txt)
+          RELEASE_URL=$(cat link.txt)
+          RELEASE_NOTES=$(cat release_notes.txt)
 
           # Claude へのお願い文（プロンプト）。媒体別に最適化した JSON を1回で生成させる
           PROMPT="あなたは開発者の広報担当です。次のリリース情報から、X(旧Twitter)・LinkedIn・Reddit 向けの告知文を日本語で作成してください。
@@ -66,8 +112,8 @@ jobs:
                   f.write(val)
           PY
 
-          # リンクは別ファイルに保存（X は本文に含めない方針）
-          echo "$RELEASE_URL" > link.txt
+          # リンクは link.txt（解決ステップで作成済み）を post ジョブへ引き継ぐ。
+          # X は本文にURLを含めない方針。
 
           # 承認画面の前に内容を確認できるよう、サマリーに表示
           {
@@ -106,6 +152,7 @@ jobs:
             linkedin.txt
             reddit_title.txt
             link.txt
+            release_name.txt
 
   # ② 承認後にだけ動く投稿ジョブ。各媒体は独立ステップ（1つ失敗しても他は続行）
   post:
@@ -199,7 +246,6 @@ jobs:
           TOKEN:            ${{ secrets.LINKEDIN_ACCESS_TOKEN }}
           PERSON_ID:        ${{ secrets.LINKEDIN_PERSON_ID }}
           LINKEDIN_VERSION: "202605"   # YYYYMM。各版はリリースから約1年で sunset → 定期更新
-          RELEASE_NAME:     ${{ github.event.release.name }}
         run: |
           set -euo pipefail
           if [ -z "${TOKEN:-}" ]; then
@@ -218,7 +264,8 @@ jobs:
           PY
           TEXT=$(cat linkedin_escaped.txt)
           LINK=$(cat link.txt)
-          TITLE="${RELEASE_NAME:-SideTimeTable}"
+          TITLE=$(cat release_name.txt)
+          TITLE="${TITLE:-SideTimeTable}"
 
           BODY=$(jq -n \
             --arg author "urn:li:person:$PERSON_ID" \


### PR DESCRIPTION
## Summary

Enable manual triggering of the release announcement workflow via `workflow_dispatch`, allowing announcements to be posted on-demand rather than relying solely on the automatic `release: published` event. This addresses the issue where `GITHUB_TOKEN`-created releases (from ci.yml) don't trigger the announcement workflow.

## Key Changes

- **Added `workflow_dispatch` trigger** with optional `tag` input to specify which release to announce (defaults to latest)
- **Added `run-name`** for better visibility of which release is being announced
- **Refactored release info resolution** into a new "Resolve release info" step that:
  - Handles both `release` event (automatic) and `workflow_dispatch` (manual) paths
  - Normalizes release data into three files: `release_name.txt`, `link.txt`, `release_notes.txt`
  - Uses GitHub CLI (`gh release view`) to fetch release details when manually triggered
  - Validates that release URL is present before proceeding
- **Updated "Generate announcement texts" step** to read normalized release info from files instead of directly from event payload
- **Updated LinkedIn posting step** to read release name from `release_name.txt` instead of event payload
- **Added `release_name.txt` to artifact uploads** for use by downstream jobs
- **Updated operational guide** (`release-announcement.md`) to document:
  - New manual workflow dispatch trigger and when to use it
  - Explanation of why automatic triggering doesn't work with ci.yml
  - Updated step-by-step release procedure (now includes manual workflow trigger)

## Implementation Details

- Release info is passed between steps via files (safer than environment variables for sensitive data)
- `jq` is used to parse GitHub CLI JSON output and extract release fields
- The workflow gracefully handles both automatic and manual triggers with the same downstream logic
- Validation ensures the release URL is resolved before proceeding to announcement generation

https://claude.ai/code/session_01XhjeFrZNmdhBRKC69R544K